### PR TITLE
Added a new connect phase and changed last_seen update policy

### DIFF
--- a/meshnow/src/event.hpp
+++ b/meshnow/src/event.hpp
@@ -15,6 +15,7 @@ enum class InternalEvent : int32_t {
     STATE_CHANGED,
     PARENT_FOUND,
     GOT_CONNECT_RESPONSE,
+    TIMEOUT_CONNECT_RESPONSE
 };
 
 struct StateChangedEvent {

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -214,7 +214,12 @@ void ConnectJob::SearchPhase::writeChannelToNVS(uint8_t channel) {
 
 // CONNECT PHASE //
 
-TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept { return 0; }
+TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept {
+    if (started_) {
+        return portMAX_DELAY;
+    }
+    return 0;
+}
 
 void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
     if (!started_) {

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -214,25 +214,12 @@ void ConnectJob::SearchPhase::writeChannelToNVS(uint8_t channel) {
 
 // CONNECT PHASE //
 
-TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept {
-    if (!started_) return 0;
-
-    if (!awaiting_connect_response_) {
-        return 0;
-    } else {
-        return last_connect_request_time_ + CONNECT_TIMEOUT;
-    }
-}
+TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept { return 0; }
 
 void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
     if (!started_) {
         ESP_LOGI(TAG, "Starting connect phase");
         started_ = true;
-    }
-
-    if (awaiting_connect_response_) {
-        ESP_LOGI(TAG, "Connect request timed out");
-        awaiting_connect_response_ = false;
     }
 
     // send a connect request to the best potential parent
@@ -246,57 +233,79 @@ void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
         return;
     }
 
-    current_parent_mac_ = it->mac_addr;
-    current_parent_rssi_ = it->rssi;
     job.parent_infos_.erase(it);
 
-    awaiting_connect_response_ = true;
-    last_connect_request_time_ = xTaskGetTickCount();
-    sendConnectRequest(current_parent_mac_);
+    ESP_LOGI(TAG, "Sending connect request to " MACSTR, MAC2STR(it->mac_addr));
+    send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(it->mac_addr));
+    job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), it->mac_addr, it->rssi);
 }
 
-void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {
-    if (event != event::InternalEvent::GOT_CONNECT_RESPONSE) return;
+void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {}
 
-    auto &response_data = *static_cast<event::GotConnectResponseData *>(event_data);
-    auto parent_mac = response_data.parent;
+// AwaitingConnectResponsePhase //
 
-    // got a wrong connection response
-    if (parent_mac != current_parent_mac_) return;
+TickType_t ConnectJob::AwaitingConnectResponsePhase::nextActionAt() const noexcept {
+    return request_sent_tick_ + CONNECT_TIMEOUT;
+}
 
-    // got a correct connection response
-    ESP_LOGI(TAG, "Got accepted by " MACSTR, MAC2STR(parent_mac));
-    awaiting_connect_response_ = false;
+void ConnectJob::AwaitingConnectResponsePhase::performAction(ConnectJob &job) {
+    if (started_) return;
 
-    // we are now connected to the parent
-    // set parent info
-    auto &layout = layout::Layout::get();
-    layout.setParent(parent_mac);
+    started_ = true;
+    ESP_LOGI(TAG, "Connect response timeout fired, retrying with next parent");
+    event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, NULL, 0);
+}
 
-    // set root mac
-    state::setRootMac(response_data.root);
+void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, event::InternalEvent event,
+                                                             void *event_data) {
+    switch (event) {
+        case event::InternalEvent::TIMEOUT_CONNECT_RESPONSE:
+            job.phase_ = ConnectPhase();
+            break;
+        case event::InternalEvent::GOT_CONNECT_RESPONSE: {
+            auto &response_data = *static_cast<event::GotConnectResponseData *>(event_data);
+            auto parent_mac = response_data.parent;
 
-    // update the state
-    // we can assume to immediately reach the root since the parent also has to reach the root
-    state::setState(state::State::REACHES_ROOT);
+            // got a wrong connection response
+            if (parent_mac != current_parent_mac_) return;
 
-    // fire connect event
-    {
-        meshnow_event_parent_connected_t parent_connected_event;
-        // printf("Connection strength is %d\n", current_parent_rssi_);
-        parent_connected_event.parent_rssi = current_parent_rssi_;
-        std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_connected_event.parent_mac);
-        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_CONNECTED, &parent_connected_event,
-                       sizeof(parent_connected_event), portMAX_DELAY);
+            // got a correct connection response
+            ESP_LOGI(TAG, "Got accepted by " MACSTR, MAC2STR(parent_mac));
+
+            // we are now connected to the parent
+            // set parent info
+            auto &layout = layout::Layout::get();
+            layout.setParent(parent_mac);
+
+            // set root mac
+            state::setRootMac(response_data.root);
+
+            // update the state
+            // we can assume to immediately reach the root since the parent also has to reach the root
+            state::setState(state::State::REACHES_ROOT);
+
+            // fire connect event
+            {
+                meshnow_event_parent_connected_t parent_connected_event;
+                // printf("Connection strength is %d\n", current_parent_rssi_);
+                parent_connected_event.parent_rssi = current_parent_rssi_;
+                std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_connected_event.parent_mac);
+                esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_CONNECTED, &parent_connected_event,
+                               sizeof(parent_connected_event), portMAX_DELAY);
+            }
+
+            //add last seen parent
+            auto& parent = layout.getParent();
+            parent.last_seen = xTaskGetTickCount();
+
+            // we now want to perform the reset
+            job.phase_ = DonePhase{};
+            break;
+        }
+        default:
+            ESP_LOGI(TAG, "Ignoring event %d in AwaitingConnectResponsePhase", static_cast<int>(event));
+            break;
     }
-
-    // we now want to perform the reset
-    job.phase_ = DonePhase{};
-}
-
-void ConnectJob::ConnectPhase::sendConnectRequest(const util::MacAddr &to_mac) {
-    ESP_LOGI(TAG, "Sending connect request to " MACSTR, MAC2STR(to_mac));
-    send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(to_mac));
 }
 
 // DonePhase //

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -233,11 +233,11 @@ void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
         return;
     }
 
-    job.parent_infos_.erase(it);
-
     ESP_LOGI(TAG, "Sending connect request to " MACSTR, MAC2STR(it->mac_addr));
     send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(it->mac_addr));
     job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), it->mac_addr, it->rssi);
+
+    job.parent_infos_.erase(it);
 }
 
 void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {}

--- a/meshnow/src/job/connect.hpp
+++ b/meshnow/src/job/connect.hpp
@@ -94,31 +94,41 @@ class ConnectJob : public Job {
 
        private:
         /**
-         * Sends a connect request to a potential parent.
-         * @param to_mac MAC address of the parent
-         */
-        static void sendConnectRequest(const util::MacAddr& to_mac);
-
-        /**
          * If this phase just been started.
          */
         bool started_{false};
+    };
 
-        /**
-         * Ticks since the last connect request was sent.
-         */
-        TickType_t last_connect_request_time_{0};
+    class AwaitingConnectResponsePhase {
+       public:
+        AwaitingConnectResponsePhase(const TickType_t request_sent_tick, util::MacAddr current_parent_mac,
+                                     int current_parent_rssi)
+            : request_sent_tick_(request_sent_tick),
+              current_parent_mac_(current_parent_mac),
+              current_parent_rssi_(current_parent_rssi) {}
 
+        TickType_t nextActionAt() const noexcept;
+        void performAction(ConnectJob &job);
+
+        void event_handler(ConnectJob &job, event::InternalEvent event, void *event_data);
+
+       private:
         /**
-         * If currently awaiting a connect response.
+         * Ticks since the connect request was sent.
          */
-        bool awaiting_connect_response_{false};
+        TickType_t request_sent_tick_;
 
         /**
          * The MAC address of the parent we are currently trying to connect to.
          */
         util::MacAddr current_parent_mac_;
+
         int current_parent_rssi_ = -128;
+
+        /**
+         * If this phase just been started.
+         */
+        bool started_{false};
     };
 
     /**
@@ -138,7 +148,7 @@ class ConnectJob : public Job {
         bool started_{false};
     };
 
-    using Phase = std::variant<SearchPhase, ConnectPhase, DonePhase>;
+    using Phase = std::variant<SearchPhase, ConnectPhase, AwaitingConnectResponsePhase, DonePhase>;
 
     static void event_handler(void* event_handler_arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
 

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -134,18 +134,11 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
 
     auto& layout = layout::Layout::get();
 
-    // is child?
-    if (layout.hasChild(meta.from)) {
-        auto& child = layout.getChild(meta.from);
-        child.last_seen = xTaskGetTickCount();
-    }
-
     // is parent?
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
         if (parent.mac != meta.from) return;
 
-        parent.last_seen = xTaskGetTickCount();
         switch (p.state) {
             case state::State::DISCONNECTED_FROM_PARENT:
             case state::State::CONNECTED_TO_PARENT: {

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -4,6 +4,27 @@
 
 #include "packets.hpp"
 #include "queue.hpp"
+#include "layout.hpp"
+
+namespace  {
+void update_last_seen(const meshnow::util::MacAddr mac) {
+    auto& layout = meshnow::layout::Layout::get();
+
+        // is child?
+    if (layout.hasChild(mac)) {
+        auto& child = layout.getChild(mac);
+        child.last_seen = xTaskGetTickCount();
+    }
+
+    // is parent?
+    if (layout.hasParent()) {
+        auto& parent = layout.getParent();
+        if (parent.mac != mac) return;
+
+        parent.last_seen = xTaskGetTickCount();
+    }
+}
+}
 
 namespace meshnow::receive {
 
@@ -11,29 +32,34 @@ namespace {
 constexpr auto TAG = CREATE_TAG("Receiver");
 }
 
-void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
-    // convert raw data pointer into buffer (vector) for deserialization TODO avoid this
-    std::vector<uint8_t> buffer(data, data + data_len);
+void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info,
+                               const uint8_t *data, int data_len) {
+  // convert raw data pointer into buffer (vector) for deserialization TODO
+  // avoid this
+  std::vector<uint8_t> buffer(data, data + data_len);
 
-    // deserialize
-    auto packet = packets::deserialize(buffer);
+  // deserialize
+  auto packet = packets::deserialize(buffer);
 
-    // if deserialization failed, ignore
-    // could happen because of interference with connecting to a router
-    if (!packet) {
-        ESP_LOGV(TAG, "Failed to deserialize packet!");
-        return;
-    }
+  // if deserialization failed, ignore
+  // could happen because of interference with connecting to a router
+  if (!packet) {
+    ESP_LOGV(TAG, "Failed to deserialize packet!");
+    return;
+  }
 
-    // create item
-    Item item{
-        util::MacAddr(esp_now_info->src_addr),
-        esp_now_info->rx_ctrl->rssi,
-        std::move(*packet),
-    };
+  // update last seen
+  update_last_seen(util::MacAddr(esp_now_info->src_addr));
 
-    // push item to queue
-    push(std::move(item));
+  // create item
+  Item item{
+      util::MacAddr(esp_now_info->src_addr),
+      esp_now_info->rx_ctrl->rssi,
+      std::move(*packet),
+  };
+
+  // push item to queue
+  push(std::move(item));
 }
 
 }  // namespace meshnow::receive


### PR DESCRIPTION
During testing we noticed two problems in the existing codebase, which have to be fixed first.

1) ConnectOk ignored despite arriving before connection request timeout

Previously, the connection request timeout was implemented by setting next_action on the ConnectPhase to time_of_connection_request_sent + connection_request_timeout. The ConnectionOk response was handled separately by the event handler, which (due to its execution order) could process the event after perform_action ran on the ConnectPhase, even if the response arrived in time.

To fix this, the timeout is now emitted as an event rather than encoded as a scheduled action. This guarantees that a ConnectionOk event is always processed before the timeout event, preserving correct ordering.

A new phase has also been introduced that runs after ConnectPhase. It inspects the outcome and either returns to ConnectPhase if the request timed out, or advances to DonePhase if the connection succeeded.

2) Only Status packets updated last_seen

Previously, last_seen was only updated when a Status packet was received. However, any packet received from a child is proof that the connection is still alive. If a child is actively sending other packet types, failing to update last_seen could cause it to be incorrectly considered inactive or timed out, despite being demonstrably reachable.

last_seen is now updated on receipt of any packet from a child, not just Status packets.

In the future the KeepAlive job can be optimised to skip sending a Status packet if another packet was already sent within the keep-alive interval.