### PR TITLE
Add new reconnect phase

### DIFF
--- a/docs/source/sdkconfig.rst
+++ b/docs/source/sdkconfig.rst
@@ -54,6 +54,12 @@ This value determines the time in milliseconds that the node waits for a reply b
 
 **Default value:** ``3000``
 
+CONFIG_RECONNECT_ATTEMPTS
+""""""""""""""""""""
+If a node fails to connect to a parent, it will retry connecting to the same parent a few times before giving up and going back to searching for new parents.
+This value determines the number of reconnect attempts.
+
+**Default value:** ``3``
 
 Keep Alive
 ^^^^^^^^^^

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -24,6 +24,13 @@ menu "MeshNOW Customization"
             A smaller value may result in failing to accept a connection because the channel is switched before a reply is received.
             A larger value may increase the time it takes to connect as the node stays longer on dead channels.
 
+    config RECONNECT_ATTEMPTS
+        int "Reconnect attempts"
+        default 3
+        help
+            If a node fails to connect to a parent, it will retry connecting to the same parent a few times before giving up and going back to searching for new parents.
+            This value determines the number of reconnect attempts.
+
     config FIRST_PARENT_WAIT
         int "First parent wait time (ms)"
         default 3000

--- a/meshnow/src/event.hpp
+++ b/meshnow/src/event.hpp
@@ -31,6 +31,7 @@ struct ParentFoundData {
 struct GotConnectResponseData {
     const util::MacAddr parent;
     const util::MacAddr root;
+    const int rssi;
 };
 
 class Internal {

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -341,6 +341,7 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
             parent.last_seen = xTaskGetTickCount();
 
             // we now want to perform the reset
+            job.reconnect_attempts_ = 0;
             job.phase_ = DonePhase{current_parent_mac_};
             break;
         }

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -219,18 +219,22 @@ void ConnectJob::SearchPhase::writeChannelToNVS(uint8_t channel) {
 
 // CONNECT PHASE //
 
+/*
+ * To connect action runs once after transitioning into it.
+ */
 TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept {
     if (started_) {
         return portMAX_DELAY;
     }
+    // By retuning 0 it ensures a check against xTaskGetTickCount() causes it to run immediately
     return 0;
 }
 
 void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
-    if (!started_) {
-        ESP_LOGI(TAG, "Starting connect phase");
-        started_ = true;
-    }
+    if (started_) return;
+
+    ESP_LOGI(TAG, "Starting connect phase");
+    started_ = true;
 
     // send a connect request to the best potential parent
 
@@ -256,11 +260,15 @@ void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEve
 
 // RECONNECT PHASE //
 
+/*
+ * To connect action runs once after transitioning into it.
+ */
 TickType_t ConnectJob::ReconnectPhase::nextActionAt() const noexcept {
-    if (!started_) {
-        return 0;
+    if (started_) {
+        return portMAX_DELAY;
     }
-    return portMAX_DELAY;
+    // By retuning 0 it ensures a check against xTaskGetTickCount() causes it to run immediately
+    return 0;
 }
 
 
@@ -289,16 +297,19 @@ void ConnectJob::ReconnectPhase::event_handler(ConnectJob &job, event::InternalE
 // AWAITING CONNECT RESPONSE PHASE //
 
 TickType_t ConnectJob::AwaitingConnectResponsePhase::nextActionAt() const noexcept {
+    if (started_) {
+        return portMAX_DELAY;
+    }
     return request_sent_tick_ + CONNECT_TIMEOUT;
 }
 
 void ConnectJob::AwaitingConnectResponsePhase::performAction(ConnectJob &job) {
     if (started_) return;
-
     started_ = true;
-    ESP_LOGI(TAG, "Connect response timeout fired (%s)",
-             origin_ == RequestOrigin::INITIAL ? "connect" : "reconnect");
+
+    ESP_LOGI(TAG, "Connect response timeout fired (%s)", origin_ == RequestOrigin::INITIAL ? "connect" : "reconnect");
     event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, nullptr, 0);
+}
 
 void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, event::InternalEvent event,
                                                              void *event_data) {

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -291,9 +291,9 @@ void ConnectJob::AwaitingConnectResponsePhase::performAction(ConnectJob &job) {
     if (started_) return;
 
     started_ = true;
-    ESP_LOGI(TAG, "Connect response timeout fired, retrying with next parent");
-    event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, NULL, 0);
-}
+    ESP_LOGI(TAG, "Connect response timeout fired (%s)",
+             origin_ == RequestOrigin::INITIAL ? "connect" : "reconnect");
+    event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, nullptr, 0);
 
 void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, event::InternalEvent event,
                                                              void *event_data) {

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -33,6 +33,9 @@ constexpr auto MAX_PARENTS_TO_CONSIDER = CONFIG_MAX_PARENTS_TO_CONSIDER;
 // Time to wait for a connection reply
 constexpr auto CONNECT_TIMEOUT = pdMS_TO_TICKS(CONFIG_CONNECT_TIMEOUT);
 
+// How many times to retry connecting to the same parent before giving up and going back to searching
+constexpr auto RECONNECT_ATTEMPTS = CONFIG_RECONNECT_ATTEMPTS;
+
 }  // namespace
 
 namespace meshnow::job {
@@ -77,6 +80,7 @@ void ConnectJob::event_handler(void *event_handler_arg, esp_event_base_t event_b
     std::visit([&](auto &phase) { phase.event_handler(job, static_cast<event::InternalEvent>(event_id), event_data); },
                job.phase_);
 }
+
 
 // SEARCH PHASE //
 
@@ -212,6 +216,7 @@ void ConnectJob::SearchPhase::writeChannelToNVS(uint8_t channel) {
     nvs_close(nvs_handle);
 }
 
+
 // CONNECT PHASE //
 
 TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept { return 0; }
@@ -237,12 +242,46 @@ void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
 
     ESP_LOGI(TAG, "Sending connect request to " MACSTR, MAC2STR(it->mac_addr));
     send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(it->mac_addr));
-    job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), it->mac_addr, it->rssi);
+    job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), it->mac_addr, RequestOrigin::INITIAL);
 }
 
+// no-op
 void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {}
 
-// AwaitingConnectResponsePhase //
+
+// RECONNECT PHASE //
+
+TickType_t ConnectJob::ReconnectPhase::nextActionAt() const noexcept {
+    if (!started_) {
+        return 0;
+    }
+    return portMAX_DELAY;
+}
+
+
+void ConnectJob::ReconnectPhase::performAction(ConnectJob &job) {
+    if (started_) return;
+    started_ = true;
+
+    if (job.reconnect_attempts_ >= RECONNECT_ATTEMPTS) {
+        ESP_LOGI(TAG, "Reconnect attempts exhausted, going back to search phase");
+        job.phase_ = SearchPhase{job.channel_config_};
+        job.reconnect_attempts_ = 0;
+        return;
+    }
+    job.reconnect_attempts_++;
+
+    // send a connect request to the current parent
+    ESP_LOGI(TAG, "Attempting reconnect to " MACSTR " (Attempt %d)",
+             MAC2STR(current_parent_mac_), job.reconnect_attempts_);
+    send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(current_parent_mac_));
+    job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), current_parent_mac_, RequestOrigin::RECONNECT);
+}
+
+// no-op
+void ConnectJob::ReconnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {  }
+
+// AWAITING CONNECT RESPONSE PHASE //
 
 TickType_t ConnectJob::AwaitingConnectResponsePhase::nextActionAt() const noexcept {
     return request_sent_tick_ + CONNECT_TIMEOUT;
@@ -260,7 +299,11 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
                                                              void *event_data) {
     switch (event) {
         case event::InternalEvent::TIMEOUT_CONNECT_RESPONSE:
-            job.phase_ = ConnectPhase();
+            if (origin_ == RequestOrigin::INITIAL) {
+                job.phase_ = ConnectPhase{};
+            } else {
+                job.phase_ = ReconnectPhase{current_parent_mac_};
+            }
             break;
         case event::InternalEvent::GOT_CONNECT_RESPONSE: {
             auto &response_data = *static_cast<event::GotConnectResponseData *>(event_data);
@@ -287,8 +330,7 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
             // fire connect event
             {
                 meshnow_event_parent_connected_t parent_connected_event;
-                // printf("Connection strength is %d\n", current_parent_rssi_);
-                parent_connected_event.parent_rssi = current_parent_rssi_;
+                parent_connected_event.parent_rssi = response_data.rssi;
                 std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_connected_event.parent_mac);
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_CONNECTED, &parent_connected_event,
                                sizeof(parent_connected_event), portMAX_DELAY);
@@ -299,7 +341,7 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
             parent.last_seen = xTaskGetTickCount();
 
             // we now want to perform the reset
-            job.phase_ = DonePhase{};
+            job.phase_ = DonePhase{current_parent_mac_};
             break;
         }
         default:
@@ -308,7 +350,8 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
     }
 }
 
-// DonePhase //
+
+// DONE PHASE //
 
 TickType_t ConnectJob::DonePhase::nextActionAt() const noexcept {
     if (!started_) {
@@ -336,7 +379,7 @@ void ConnectJob::DonePhase::event_handler(meshnow::job::ConnectJob &job, event::
     ESP_LOGI(TAG, "new State: %d", static_cast<uint8_t>(state_change.new_state));
 
     if (state_change.new_state == state::State::DISCONNECTED_FROM_PARENT) {
-        job.phase_ = SearchPhase{job.channel_config_};
+        job.phase_ = ReconnectPhase{current_parent_mac_};
     }
 }
 

--- a/meshnow/src/job/connect.hpp
+++ b/meshnow/src/job/connect.hpp
@@ -99,13 +99,14 @@ class ConnectJob : public Job {
         bool started_{false};
     };
 
+    enum class RequestOrigin : uint8_t { INITIAL = 0, RECONNECT = 1 };
+
     class AwaitingConnectResponsePhase {
        public:
-        AwaitingConnectResponsePhase(const TickType_t request_sent_tick, util::MacAddr current_parent_mac,
-                                     int current_parent_rssi)
+        AwaitingConnectResponsePhase(const TickType_t request_sent_tick, util::MacAddr current_parent_mac, RequestOrigin origin)
             : request_sent_tick_(request_sent_tick),
               current_parent_mac_(current_parent_mac),
-              current_parent_rssi_(current_parent_rssi) {}
+              origin_(origin){}
 
         TickType_t nextActionAt() const noexcept;
         void performAction(ConnectJob &job);
@@ -123,12 +124,39 @@ class ConnectJob : public Job {
          */
         util::MacAddr current_parent_mac_;
 
-        int current_parent_rssi_ = -128;
-
         /**
          * If this phase just been started.
          */
         bool started_{false};
+
+        /**
+         * Used to determine which phase to revert to in the event of a timeout.
+         */
+        RequestOrigin origin_;
+    };
+    
+
+    /**
+     * Reconnect phase, used when attempting to re-establish connection with a previously connected parent.
+     */
+    
+    class ReconnectPhase {
+       public:
+        ReconnectPhase(const util::MacAddr& parent_mac) : current_parent_mac_(parent_mac) {}
+        TickType_t nextActionAt() const noexcept;
+        void performAction(ConnectJob &job);
+        void event_handler(ConnectJob& job, event::InternalEvent event, void* event_data);
+
+       private:
+        /**
+         * If this phase just been started.
+         */
+        bool started_{false};
+
+         /**
+         * The MAC address of the parent we are currently trying to connect to.
+         */
+        util::MacAddr current_parent_mac_;
     };
 
     /**
@@ -136,6 +164,8 @@ class ConnectJob : public Job {
      */
     class DonePhase {
        public:
+       DonePhase(const util::MacAddr& parent_mac) 
+            : current_parent_mac_(parent_mac) {}
         TickType_t nextActionAt() const noexcept;
         void performAction(ConnectJob& job);
 
@@ -146,9 +176,13 @@ class ConnectJob : public Job {
          * If this phase just been started.
          */
         bool started_{false};
+        /**
+         * The MAC address of the parent we are currently trying to connect to.
+         */
+        util::MacAddr current_parent_mac_;
     };
 
-    using Phase = std::variant<SearchPhase, ConnectPhase, AwaitingConnectResponsePhase, DonePhase>;
+    using Phase = std::variant<SearchPhase, ConnectPhase, ReconnectPhase, AwaitingConnectResponsePhase, DonePhase>;
 
     static void event_handler(void* event_handler_arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
 
@@ -159,6 +193,8 @@ class ConnectJob : public Job {
     std::vector<ParentInfo> parent_infos_;
     // starts per default with SearchPhase
     Phase phase_{SearchPhase{channel_config_}};
+    // number of reconnect attempts made in the current reconnect phase
+    uint8_t reconnect_attempts_{0};
 };
 
 }  // namespace meshnow::job

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -220,6 +220,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
     event::GotConnectResponseData data{
         .parent = meta.from,
         .root = p.root,
+        .rssi = meta.rssi
     };
     event::Internal::fire(event::InternalEvent::GOT_CONNECT_RESPONSE, &data, sizeof(data));
 }


### PR DESCRIPTION
Until now there were 4 phases defined in the /src/job/connect.cpp: 

- Search
- Await Connect Response 
- Connect
- Done

If there was a short disconnect from the parent (`DISCONNECTED_FROM_PARENT` state) then it went from the "Done" phase back into the "Search" phase. 

To ensure stickiness we have added a new phase which is named "Reconnect". This phase tries to reconnect to same parent `RECONNECT_ATTEMPTS` times (new variable we've added, now is set to 3) and if the attempts are exhausted then it goes back to the "Search" phase. 

Now the "Done" Phase goes directly into the "Reconnect" phase, enabling stable topology and less overhead. 

Also previously the `meshnow_event_parent_connected_t` contained the RSSI from the `SearchReply` packet, now the RSSI from the SearchReply is only used for picking the best parent and then the RSSI from the `ConnectOk` packet is used to set it in the `meshnow_event_parent_connected_t`.⁦     

Tests we have used to check the functionality: 
1. "Killing" a parent node and leaving it "dead" for some time and seeing how the node goes into the "Search" phase after all connection attempts.
2. By "killing" a parent and turning it on back fast, to see how the child reconnects to the same parent. 