### PR TITLE
2026/n1/merged test

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2023 CAPS-IoT
+Copyright (c) 2023 Marvin Bauer
+Copyright (c) 2023-2026 CAPS-IoT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/source/sdkconfig.rst
+++ b/docs/source/sdkconfig.rst
@@ -54,6 +54,12 @@ This value determines the time in milliseconds that the node waits for a reply b
 
 **Default value:** ``3000``
 
+CONFIG_RECONNECT_ATTEMPTS
+""""""""""""""""""""
+If a node fails to connect to a parent, it will retry connecting to the same parent a few times before giving up and going back to searching for new parents.
+This value determines the number of reconnect attempts.
+
+**Default value:** ``3``
 
 Keep Alive
 ^^^^^^^^^^

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -24,6 +24,13 @@ menu "MeshNOW Customization"
             A smaller value may result in failing to accept a connection because the channel is switched before a reply is received.
             A larger value may increase the time it takes to connect as the node stays longer on dead channels.
 
+    config RECONNECT_ATTEMPTS
+        int "Reconnect attempts"
+        default 3
+        help
+            If a node fails to connect to a parent, it will retry connecting to the same parent a few times before giving up and going back to searching for new parents.
+            This value determines the number of reconnect attempts.
+
     config FIRST_PARENT_WAIT
         int "First parent wait time (ms)"
         default 3000

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -102,67 +102,67 @@ menu "MeshNOW Customization"
     
     config STATUS_MESSAGE_LEVEL
         int "status message level"
-        default 1
+        default 0
         help 
             Priority level of status messages.
         
     config SEARCH_PROBE_MESSAGE_LEVEL
         int "search probe message level"
-        default 1
+        default 0
         help 
             Priority level of search probe messages.
 
     config SEARCH_REPLY_MESSAGE_LEVEL
         int "search reply message level"
-        default 1
+        default 0
         help 
             Priority level of search reply messages.
 
     config CONNECT_REQUEST_MESSAGE_LEVEL
         int "connect request message level"
-        default 1
+        default 0
         help 
             Priority level of connecty request messages.
 
     config CONNECT_OK_MESSAGE_LEVEL
-    int "connect ok message level"
-    default 1
-    help
-        Priority level of connect ok messages.
+        int "connect ok message level"
+        default 0
+        help
+            Priority level of connect ok messages.
 
     config ROUTING_TABLE_ADD_MESSAGE_LEVEL
         int "routing table add message level"
-        default 1
+        default 0
         help
             Priority level of routing table add messages.
 
     config ROUTING_TABLE_REMOVE_MESSAGE_LEVEL
         int "routing table remove message level"
-        default 1
+        default 0
         help
             Priority level of routing table remove messages.
 
     config ROOT_UNREACHABLE_MESSAGE_LEVEL
         int "root unreachable message level"
-        default 1
+        default 0
         help
             Priority level of root unreachable messages.
 
     config ROOT_REACHABLE_MESSAGE_LEVEL
         int "root reachable message level"
-        default 1
+        default 0
         help
             Priority level of root reachable messages.
 
     config DATA_FRAGMENT_MESSAGE_LEVEL
         int "data fragment message level"
-        default 1
+        default 0
         help
             Priority level of data fragment messages.
 
     config CUSTOM_DATA_MESSAGE_LEVEL
         int "custom data message level"
-        default 1
+        default 0
         help
             Priority level of custom data messages.
 

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -83,4 +83,87 @@ menu "MeshNOW Customization"
         help
             The IP address of the DNS server that is used for DNS lookups. This value is encoded as a 4-byte hex value.
 
+    config RECEIVER_PRIORITY_QUEUE_LEVELS
+        int "receiver priority queue levels number"
+        default 1
+        help
+            Specify the number of priority levels used in the receiver. If set to 1, then all messages will have the same priority level.
+            Othewise, the level of priority of different types of messages can help processing important messages sooner than less important
+            ones. The priority level of each kind of message can also be set. 
+    
+    config MESSAGES_PER_PRIORITY_LEVEL
+        int "messages per priority level"
+        default 2
+        help
+            This parameter specify the maximum number of messages with priority level i that will processed one after the other until some 
+            message with lower priority is also processed. If MESSAGES_PER_PRIORITY_LEVEL = n, then, for a priority level i, this number 
+            will be (RECEIVER_PRIORITY_QUEUE_LEVELS - i)*n. Hence, the higher the level of priority, the lower this number. This allows 
+            to make less important messages be processed even if the higher levels are used, and thus ensures some fairness.
+    
+    config STATUS_MESSAGE_LEVEL
+        int "status message level"
+        default 1
+        help 
+            Priority level of status messages.
+        
+    config SEARCH_PROBE_MESSAGE_LEVEL
+        int "search probe message level"
+        default 1
+        help 
+            Priority level of search probe messages.
+
+    config SEARCH_REPLY_MESSAGE_LEVEL
+        int "search reply message level"
+        default 1
+        help 
+            Priority level of search reply messages.
+
+    config CONNECT_REQUEST_MESSAGE_LEVEL
+        int "connect request message level"
+        default 1
+        help 
+            Priority level of connecty request messages.
+
+    config CONNECT_OK_MESSAGE_LEVEL
+    int "connect ok message level"
+    default 1
+    help
+        Priority level of connect ok messages.
+
+    config ROUTING_TABLE_ADD_MESSAGE_LEVEL
+        int "routing table add message level"
+        default 1
+        help
+            Priority level of routing table add messages.
+
+    config ROUTING_TABLE_REMOVE_MESSAGE_LEVEL
+        int "routing table remove message level"
+        default 1
+        help
+            Priority level of routing table remove messages.
+
+    config ROOT_UNREACHABLE_MESSAGE_LEVEL
+        int "root unreachable message level"
+        default 1
+        help
+            Priority level of root unreachable messages.
+
+    config ROOT_REACHABLE_MESSAGE_LEVEL
+        int "root reachable message level"
+        default 1
+        help
+            Priority level of root reachable messages.
+
+    config DATA_FRAGMENT_MESSAGE_LEVEL
+        int "data fragment message level"
+        default 1
+        help
+            Priority level of data fragment messages.
+
+    config CUSTOM_DATA_MESSAGE_LEVEL
+        int "custom data message level"
+        default 1
+        help
+            Priority level of custom data messages.
+
 endmenu

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -46,6 +46,26 @@ menu "MeshNOW Customization"
             During the search phase, the node keeps track of only a few parents at a time to save memory and speed up the connection process.
             This value determines the maximum number of parents that the node keeps track of. If a better parent is found, the node will replace the worst parent it is tracking.
 
+    config USE_CONNECT_OK_ACK_MESSAGE
+        int "Use connect ok ack message to validate the reception of a connect ok message"
+        default 1
+        help 
+            Use connect ok ack message to validate the reception of a connect ok message. The parent registers the child only when it receives an connect ok ack message.
+            When it receives a connect request, it sends back a connect ok, to which the child respond with a connect ok ack
+    
+    config USE_CONNECT_END_MESSAGE
+        int "Use connect end message"
+        default 1
+        help
+            Sending an end of connection message to tear down a connection rather than waiting for the neighbor to time out.
+
+    config USE_RTT_FOR_TIMEOUT
+        int "Use round-trip-time (RTT) to compute timeout"
+        default 1
+        help
+            Instead of having a hard-threshold time out, use an estimate of the time it takes for two neighbors to communicate. Samples of RTT are computed by changing the behavior of status packets, 
+            so that they can be responded to, and the first and second moments are estimated by using a leaky integrator. The timeout is then specific to each neighbor, and a function of the first 
+            and second moments of the RTT.
     config CONNECT_TIMEOUT
         int "Connection timeout (ms)"
         default 3000

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -137,6 +137,18 @@ menu "MeshNOW Customization"
         help
             Priority level of connect ok messages.
 
+    config CONNECT_OK_ACK_MESSAGE_LEVEL
+        int "connect ok ack message level"
+        default 0
+        help
+            Priority level of connect ok ack messages.
+    
+    config CONNECT_END_MESSAGE_LEVEL
+        int "connect end message level"
+        default 0
+        help
+            Priority level of connect end messages.
+
     config ROUTING_TABLE_ADD_MESSAGE_LEVEL
         int "routing table add message level"
         default 0

--- a/meshnow/src/event.hpp
+++ b/meshnow/src/event.hpp
@@ -31,6 +31,7 @@ struct ParentFoundData {
 struct GotConnectResponseData {
     const util::MacAddr parent;
     const util::MacAddr root;
+    const int rssi;
 };
 
 class Internal {

--- a/meshnow/src/event.hpp
+++ b/meshnow/src/event.hpp
@@ -15,6 +15,7 @@ enum class InternalEvent : int32_t {
     STATE_CHANGED,
     PARENT_FOUND,
     GOT_CONNECT_RESPONSE,
+    TIMEOUT_CONNECT_RESPONSE
 };
 
 struct StateChangedEvent {

--- a/meshnow/src/include/meshnow.h
+++ b/meshnow/src/include/meshnow.h
@@ -77,6 +77,8 @@ typedef struct {
      * MAC address of the parent to which this node connected.
      */
     meshnow_addr_t parent_mac;
+    int parent_rssi;
+    
 } meshnow_event_parent_connected_t;
 
 /**

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -341,6 +341,7 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
             parent.last_seen = xTaskGetTickCount();
 
             // we now want to perform the reset
+            job.reconnect_attempts_ = 0;
             job.phase_ = DonePhase{current_parent_mac_};
             break;
         }

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -291,9 +291,9 @@ void ConnectJob::AwaitingConnectResponsePhase::performAction(ConnectJob &job) {
     if (started_) return;
 
     started_ = true;
-    ESP_LOGI(TAG, "Connect response timeout fired, retrying with next parent");
-    event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, NULL, 0);
-}
+    ESP_LOGI(TAG, "Connect response timeout fired (%s)",
+             origin_ == RequestOrigin::INITIAL ? "connect" : "reconnect");
+    event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, nullptr, 0);
 
 void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, event::InternalEvent event,
                                                              void *event_data) {

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -33,6 +33,9 @@ constexpr auto MAX_PARENTS_TO_CONSIDER = CONFIG_MAX_PARENTS_TO_CONSIDER;
 // Time to wait for a connection reply
 constexpr auto CONNECT_TIMEOUT = pdMS_TO_TICKS(CONFIG_CONNECT_TIMEOUT);
 
+// How many times to retry connecting to the same parent before giving up and going back to searching
+constexpr auto RECONNECT_ATTEMPTS = CONFIG_RECONNECT_ATTEMPTS;
+
 }  // namespace
 
 namespace meshnow::job {
@@ -77,6 +80,7 @@ void ConnectJob::event_handler(void *event_handler_arg, esp_event_base_t event_b
     std::visit([&](auto &phase) { phase.event_handler(job, static_cast<event::InternalEvent>(event_id), event_data); },
                job.phase_);
 }
+
 
 // SEARCH PHASE //
 
@@ -212,6 +216,7 @@ void ConnectJob::SearchPhase::writeChannelToNVS(uint8_t channel) {
     nvs_close(nvs_handle);
 }
 
+
 // CONNECT PHASE //
 
 TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept { return 0; }
@@ -237,12 +242,46 @@ void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
 
     ESP_LOGI(TAG, "Sending connect request to " MACSTR, MAC2STR(it->mac_addr));
     send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(it->mac_addr));
-    job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), it->mac_addr, it->rssi);
+    job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), it->mac_addr, RequestOrigin::INITIAL);
 }
 
+// no-op
 void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {}
 
-// AwaitingConnectResponsePhase //
+
+// RECONNECT PHASE //
+
+TickType_t ConnectJob::ReconnectPhase::nextActionAt() const noexcept {
+    if (!started_) {
+        return 0;
+    }
+    return portMAX_DELAY;
+}
+
+
+void ConnectJob::ReconnectPhase::performAction(ConnectJob &job) {
+    if (started_) return;
+    started_ = true;
+
+    if (job.reconnect_attempts_ >= RECONNECT_ATTEMPTS) {
+        ESP_LOGI(TAG, "Reconnect attempts exhausted, going back to search phase");
+        job.phase_ = SearchPhase{job.channel_config_};
+        job.reconnect_attempts_ = 0;
+        return;
+    }
+    job.reconnect_attempts_++;
+
+    // send a connect request to the current parent
+    ESP_LOGI(TAG, "Attempting reconnect to " MACSTR " (Attempt %d)",
+             MAC2STR(current_parent_mac_), job.reconnect_attempts_);
+    send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(current_parent_mac_));
+    job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), current_parent_mac_, RequestOrigin::RECONNECT);
+}
+
+// no-op
+void ConnectJob::ReconnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {  }
+
+// AWAITING CONNECT RESPONSE PHASE //
 
 TickType_t ConnectJob::AwaitingConnectResponsePhase::nextActionAt() const noexcept {
     return request_sent_tick_ + CONNECT_TIMEOUT;
@@ -260,7 +299,11 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
                                                              void *event_data) {
     switch (event) {
         case event::InternalEvent::TIMEOUT_CONNECT_RESPONSE:
-            job.phase_ = ConnectPhase();
+            if (origin_ == RequestOrigin::INITIAL) {
+                job.phase_ = ConnectPhase{};
+            } else {
+                job.phase_ = ReconnectPhase{current_parent_mac_};
+            }
             break;
         case event::InternalEvent::GOT_CONNECT_RESPONSE: {
             auto &response_data = *static_cast<event::GotConnectResponseData *>(event_data);
@@ -287,8 +330,7 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
             // fire connect event
             {
                 meshnow_event_parent_connected_t parent_connected_event;
-                // printf("Connection strength is %d\n", current_parent_rssi_);
-                parent_connected_event.parent_rssi = current_parent_rssi_;
+                parent_connected_event.parent_rssi = response_data.rssi;
                 std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_connected_event.parent_mac);
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_CONNECTED, &parent_connected_event,
                                sizeof(parent_connected_event), portMAX_DELAY);
@@ -299,7 +341,7 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
             parent.last_seen = xTaskGetTickCount();
 
             // we now want to perform the reset
-            job.phase_ = DonePhase{};
+            job.phase_ = DonePhase{current_parent_mac_};
             break;
         }
         default:
@@ -308,7 +350,8 @@ void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, ev
     }
 }
 
-// DonePhase //
+
+// DONE PHASE //
 
 TickType_t ConnectJob::DonePhase::nextActionAt() const noexcept {
     if (!started_) {
@@ -336,7 +379,7 @@ void ConnectJob::DonePhase::event_handler(meshnow::job::ConnectJob &job, event::
     ESP_LOGI(TAG, "new State: %d", static_cast<uint8_t>(state_change.new_state));
 
     if (state_change.new_state == state::State::DISCONNECTED_FROM_PARENT) {
-        job.phase_ = SearchPhase{job.channel_config_};
+        job.phase_ = ReconnectPhase{current_parent_mac_};
     }
 }
 

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -247,6 +247,7 @@ void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
     }
 
     current_parent_mac_ = it->mac_addr;
+    current_parent_rssi_ = it->rssi;
     job.parent_infos_.erase(it);
 
     awaiting_connect_response_ = true;
@@ -282,6 +283,8 @@ void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEve
     // fire connect event
     {
         meshnow_event_parent_connected_t parent_connected_event;
+        // printf("Connection strength is %d\n", current_parent_rssi_);
+        parent_connected_event.parent_rssi = current_parent_rssi_;
         std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_connected_event.parent_mac);
         esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_CONNECTED, &parent_connected_event,
                        sizeof(parent_connected_event), portMAX_DELAY);

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -214,25 +214,12 @@ void ConnectJob::SearchPhase::writeChannelToNVS(uint8_t channel) {
 
 // CONNECT PHASE //
 
-TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept {
-    if (!started_) return 0;
-
-    if (!awaiting_connect_response_) {
-        return 0;
-    } else {
-        return last_connect_request_time_ + CONNECT_TIMEOUT;
-    }
-}
+TickType_t ConnectJob::ConnectPhase::nextActionAt() const noexcept { return 0; }
 
 void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
     if (!started_) {
         ESP_LOGI(TAG, "Starting connect phase");
         started_ = true;
-    }
-
-    if (awaiting_connect_response_) {
-        ESP_LOGI(TAG, "Connect request timed out");
-        awaiting_connect_response_ = false;
     }
 
     // send a connect request to the best potential parent
@@ -246,57 +233,79 @@ void ConnectJob::ConnectPhase::performAction(ConnectJob &job) {
         return;
     }
 
-    current_parent_mac_ = it->mac_addr;
-    current_parent_rssi_ = it->rssi;
     job.parent_infos_.erase(it);
 
-    awaiting_connect_response_ = true;
-    last_connect_request_time_ = xTaskGetTickCount();
-    sendConnectRequest(current_parent_mac_);
+    ESP_LOGI(TAG, "Sending connect request to " MACSTR, MAC2STR(it->mac_addr));
+    send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(it->mac_addr));
+    job.phase_ = AwaitingConnectResponsePhase(xTaskGetTickCount(), it->mac_addr, it->rssi);
 }
 
-void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {
-    if (event != event::InternalEvent::GOT_CONNECT_RESPONSE) return;
+void ConnectJob::ConnectPhase::event_handler(ConnectJob &job, event::InternalEvent event, void *event_data) {}
 
-    auto &response_data = *static_cast<event::GotConnectResponseData *>(event_data);
-    auto parent_mac = response_data.parent;
+// AwaitingConnectResponsePhase //
 
-    // got a wrong connection response
-    if (parent_mac != current_parent_mac_) return;
+TickType_t ConnectJob::AwaitingConnectResponsePhase::nextActionAt() const noexcept {
+    return request_sent_tick_ + CONNECT_TIMEOUT;
+}
 
-    // got a correct connection response
-    ESP_LOGI(TAG, "Got accepted by " MACSTR, MAC2STR(parent_mac));
-    awaiting_connect_response_ = false;
+void ConnectJob::AwaitingConnectResponsePhase::performAction(ConnectJob &job) {
+    if (started_) return;
 
-    // we are now connected to the parent
-    // set parent info
-    auto &layout = layout::Layout::get();
-    layout.setParent(parent_mac);
+    started_ = true;
+    ESP_LOGI(TAG, "Connect response timeout fired, retrying with next parent");
+    event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, NULL, 0);
+}
 
-    // set root mac
-    state::setRootMac(response_data.root);
+void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, event::InternalEvent event,
+                                                             void *event_data) {
+    switch (event) {
+        case event::InternalEvent::TIMEOUT_CONNECT_RESPONSE:
+            job.phase_ = ConnectPhase();
+            break;
+        case event::InternalEvent::GOT_CONNECT_RESPONSE: {
+            auto &response_data = *static_cast<event::GotConnectResponseData *>(event_data);
+            auto parent_mac = response_data.parent;
 
-    // update the state
-    // we can assume to immediately reach the root since the parent also has to reach the root
-    state::setState(state::State::REACHES_ROOT);
+            // got a wrong connection response
+            if (parent_mac != current_parent_mac_) return;
 
-    // fire connect event
-    {
-        meshnow_event_parent_connected_t parent_connected_event;
-        // printf("Connection strength is %d\n", current_parent_rssi_);
-        parent_connected_event.parent_rssi = current_parent_rssi_;
-        std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_connected_event.parent_mac);
-        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_CONNECTED, &parent_connected_event,
-                       sizeof(parent_connected_event), portMAX_DELAY);
+            // got a correct connection response
+            ESP_LOGI(TAG, "Got accepted by " MACSTR, MAC2STR(parent_mac));
+
+            // we are now connected to the parent
+            // set parent info
+            auto &layout = layout::Layout::get();
+            layout.setParent(parent_mac);
+
+            // set root mac
+            state::setRootMac(response_data.root);
+
+            // update the state
+            // we can assume to immediately reach the root since the parent also has to reach the root
+            state::setState(state::State::REACHES_ROOT);
+
+            // fire connect event
+            {
+                meshnow_event_parent_connected_t parent_connected_event;
+                // printf("Connection strength is %d\n", current_parent_rssi_);
+                parent_connected_event.parent_rssi = current_parent_rssi_;
+                std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_connected_event.parent_mac);
+                esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_CONNECTED, &parent_connected_event,
+                               sizeof(parent_connected_event), portMAX_DELAY);
+            }
+
+            //add last seen parent
+            auto& parent = layout.getParent();
+            parent.last_seen = xTaskGetTickCount();
+
+            // we now want to perform the reset
+            job.phase_ = DonePhase{};
+            break;
+        }
+        default:
+            ESP_LOGI(TAG, "Ignoring event %d in AwaitingConnectResponsePhase", static_cast<int>(event));
+            break;
     }
-
-    // we now want to perform the reset
-    job.phase_ = DonePhase{};
-}
-
-void ConnectJob::ConnectPhase::sendConnectRequest(const util::MacAddr &to_mac) {
-    ESP_LOGI(TAG, "Sending connect request to " MACSTR, MAC2STR(to_mac));
-    send::enqueuePayload(packets::ConnectRequest{}, send::DirectOnce(to_mac));
 }
 
 // DonePhase //

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -294,6 +294,7 @@ void ConnectJob::AwaitingConnectResponsePhase::performAction(ConnectJob &job) {
     ESP_LOGI(TAG, "Connect response timeout fired (%s)",
              origin_ == RequestOrigin::INITIAL ? "connect" : "reconnect");
     event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, nullptr, 0);
+}
 
 void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, event::InternalEvent event,
                                                              void *event_data) {

--- a/meshnow/src/job/connect.hpp
+++ b/meshnow/src/job/connect.hpp
@@ -99,13 +99,14 @@ class ConnectJob : public Job {
         bool started_{false};
     };
 
+    enum class RequestOrigin : uint8_t { INITIAL = 0, RECONNECT = 1 };
+
     class AwaitingConnectResponsePhase {
        public:
-        AwaitingConnectResponsePhase(const TickType_t request_sent_tick, util::MacAddr current_parent_mac,
-                                     int current_parent_rssi)
+        AwaitingConnectResponsePhase(const TickType_t request_sent_tick, util::MacAddr current_parent_mac, RequestOrigin origin)
             : request_sent_tick_(request_sent_tick),
               current_parent_mac_(current_parent_mac),
-              current_parent_rssi_(current_parent_rssi) {}
+              origin_(origin){}
 
         TickType_t nextActionAt() const noexcept;
         void performAction(ConnectJob &job);
@@ -123,12 +124,39 @@ class ConnectJob : public Job {
          */
         util::MacAddr current_parent_mac_;
 
-        int current_parent_rssi_ = -128;
-
         /**
          * If this phase just been started.
          */
         bool started_{false};
+
+        /**
+         * Used to determine which phase to revert to in the event of a timeout.
+         */
+        RequestOrigin origin_;
+    };
+    
+
+    /**
+     * Reconnect phase, used when attempting to re-establish connection with a previously connected parent.
+     */
+    
+    class ReconnectPhase {
+       public:
+        ReconnectPhase(const util::MacAddr& parent_mac) : current_parent_mac_(parent_mac) {}
+        TickType_t nextActionAt() const noexcept;
+        void performAction(ConnectJob &job);
+        void event_handler(ConnectJob& job, event::InternalEvent event, void* event_data);
+
+       private:
+        /**
+         * If this phase just been started.
+         */
+        bool started_{false};
+
+         /**
+         * The MAC address of the parent we are currently trying to connect to.
+         */
+        util::MacAddr current_parent_mac_;
     };
 
     /**
@@ -136,6 +164,8 @@ class ConnectJob : public Job {
      */
     class DonePhase {
        public:
+       DonePhase(const util::MacAddr& parent_mac) 
+            : current_parent_mac_(parent_mac) {}
         TickType_t nextActionAt() const noexcept;
         void performAction(ConnectJob& job);
 
@@ -146,9 +176,13 @@ class ConnectJob : public Job {
          * If this phase just been started.
          */
         bool started_{false};
+        /**
+         * The MAC address of the parent we are currently trying to connect to.
+         */
+        util::MacAddr current_parent_mac_;
     };
 
-    using Phase = std::variant<SearchPhase, ConnectPhase, AwaitingConnectResponsePhase, DonePhase>;
+    using Phase = std::variant<SearchPhase, ConnectPhase, ReconnectPhase, AwaitingConnectResponsePhase, DonePhase>;
 
     static void event_handler(void* event_handler_arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
 
@@ -159,6 +193,8 @@ class ConnectJob : public Job {
     std::vector<ParentInfo> parent_infos_;
     // starts per default with SearchPhase
     Phase phase_{SearchPhase{channel_config_}};
+    // number of reconnect attempts made in the current reconnect phase
+    uint8_t reconnect_attempts_{0};
 };
 
 }  // namespace meshnow::job

--- a/meshnow/src/job/connect.hpp
+++ b/meshnow/src/job/connect.hpp
@@ -94,31 +94,41 @@ class ConnectJob : public Job {
 
        private:
         /**
-         * Sends a connect request to a potential parent.
-         * @param to_mac MAC address of the parent
-         */
-        static void sendConnectRequest(const util::MacAddr& to_mac);
-
-        /**
          * If this phase just been started.
          */
         bool started_{false};
+    };
 
-        /**
-         * Ticks since the last connect request was sent.
-         */
-        TickType_t last_connect_request_time_{0};
+    class AwaitingConnectResponsePhase {
+       public:
+        AwaitingConnectResponsePhase(const TickType_t request_sent_tick, util::MacAddr current_parent_mac,
+                                     int current_parent_rssi)
+            : request_sent_tick_(request_sent_tick),
+              current_parent_mac_(current_parent_mac),
+              current_parent_rssi_(current_parent_rssi) {}
 
+        TickType_t nextActionAt() const noexcept;
+        void performAction(ConnectJob &job);
+
+        void event_handler(ConnectJob &job, event::InternalEvent event, void *event_data);
+
+       private:
         /**
-         * If currently awaiting a connect response.
+         * Ticks since the connect request was sent.
          */
-        bool awaiting_connect_response_{false};
+        TickType_t request_sent_tick_;
 
         /**
          * The MAC address of the parent we are currently trying to connect to.
          */
         util::MacAddr current_parent_mac_;
+
         int current_parent_rssi_ = -128;
+
+        /**
+         * If this phase just been started.
+         */
+        bool started_{false};
     };
 
     /**
@@ -138,7 +148,7 @@ class ConnectJob : public Job {
         bool started_{false};
     };
 
-    using Phase = std::variant<SearchPhase, ConnectPhase, DonePhase>;
+    using Phase = std::variant<SearchPhase, ConnectPhase, AwaitingConnectResponsePhase, DonePhase>;
 
     static void event_handler(void* event_handler_arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
 

--- a/meshnow/src/job/connect.hpp
+++ b/meshnow/src/job/connect.hpp
@@ -118,6 +118,7 @@ class ConnectJob : public Job {
          * The MAC address of the parent we are currently trying to connect to.
          */
         util::MacAddr current_parent_mac_;
+        int current_parent_rssi_ = -128;
     };
 
     /**

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -50,11 +50,15 @@ void StatusSendJob::sendStatus() {
         packets::Status payload{
             .state = state,
             .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
+            #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
+            //odd means seq
             .seq = child.rtt_seq | 1,
+            #endif
         };
+        #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
         child.rtt_seq += 2;
         child.last_seen_rtt = xTaskGetTickCount();
-
+        #endif
         send::enqueuePayload(payload, send::DirectOnce{child.mac});
     }
     if (layout.hasParent()) {
@@ -62,10 +66,15 @@ void StatusSendJob::sendStatus() {
         packets::Status payload{
             .state = state,
             .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
-            .seq = parent.rtt_seq,
+            #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
+            //odd means seq
+            .seq = parent.rtt_seq | 1,
+            #endif
         };
-        parent.rtt_seq += 1;
+        #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
+        parent.rtt_seq += 2;
         parent.last_seen_rtt = xTaskGetTickCount();
+        #endif
 
         send::enqueuePayload(payload, send::DirectOnce{parent.mac});
     }
@@ -166,7 +175,11 @@ void NeighborCheckJob::performAction() {
 
     // direct children
     for (auto it = layout.getChildren().begin(); it != layout.getChildren().end();) {
+        #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
         auto timeout = it->rtt_est + 4*it->rtt_dev_est;
+        #else
+        auto timeout = KEEP_ALIVE_TIMEOUT;
+        #endif
         if (now - it->last_seen > timeout) {
             auto mac = it->mac;
             ESP_LOGW(TAG, "Direct child " MACSTR " timed out (timeout %d)", MAC2STR(mac), timeout);
@@ -178,8 +191,9 @@ void NeighborCheckJob::performAction() {
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
                                &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
             }
-
+            #ifdef CONFIG_USE_CONNECT_END_MESSAGE
             send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(mac));
+            #endif
 
             layout.removeChild(it->mac);
             // send event upstream
@@ -192,7 +206,11 @@ void NeighborCheckJob::performAction() {
     // parent
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
+        #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
         auto timeout = parent.rtt_est + 4*parent.rtt_dev_est;
+        #else 
+        auto timeout = KEEP_ALIVE_TIMEOUT;
+        #endif
         if (now - parent.last_seen > timeout) {
             ESP_LOGW(TAG, "Parent " MACSTR " timed out (timeout)", MAC2STR(parent.mac), timeout);
 
@@ -204,9 +222,10 @@ void NeighborCheckJob::performAction() {
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
-
+            #ifdef CONFIG_USE_CONNECT_END_MESSAGE
             // Send the ConnectEnd packet
             send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(parent.mac));
+            #endif
 
             layout.removeParent();
             state::setState(state::State::DISCONNECTED_FROM_PARENT);

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -73,22 +73,22 @@ void UnreachableTimeoutJob::performAction() {
         // if we haven't lost the parent by now because of a Keep Alive timeout, remove it
         auto& layout = layout::Layout::get();
         if (layout.hasParent()) {
+            auto parent_mac = layout.getParent().mac;
+
             // fire disconnect event
             {
                 meshnow_event_parent_disconnected_t parent_disconnected_event;
-                util::MacAddr& parent_mac = layout::Layout::get().getParent().mac;
                 std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_disconnected_event.parent_mac);
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
-            
+
             // Send the ConnectEnd packet
-            auto payload = packets::ConnectEnd{};
-            send::enqueuePayload(payload, send::DirectOnce{parent.mac});
+            send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(parent_mac));
+
             layout.removeParent();
-            state::setState(state::State::DISCONNECTED_FROM_PARENT);  // set state to disconnected
+            state::setState(state::State::DISCONNECTED_FROM_PARENT);
         }
-}
     }
 }
 
@@ -162,6 +162,8 @@ void NeighborCheckJob::performAction() {
                                &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
             }
 
+            send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(mac));
+
             layout.removeChild(it->mac);
             // send event upstream
             sendChildDisconnected(mac);
@@ -186,8 +188,8 @@ void NeighborCheckJob::performAction() {
             }
 
             // Send the ConnectEnd packet
-            auto payload = packets::ConnectEnd{};
-            send::enqueuePayload(payload, send::DirectOnce{parent.mac});
+            send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(parent.mac));
+
             layout.removeParent();
             state::setState(state::State::DISCONNECTED_FROM_PARENT);
         }

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -182,7 +182,7 @@ void NeighborCheckJob::performAction() {
         #endif
         if (now - it->last_seen > timeout) {
             auto mac = it->mac;
-            ESP_LOGW(TAG, "Direct child " MACSTR " timed out (timeout %d)", MAC2STR(mac), timeout);
+            ESP_LOGW(TAG, "Direct child " MACSTR " timed out (timeout %lu)", MAC2STR(mac), timeout);
 
             // fire disconnect event
             {
@@ -212,7 +212,7 @@ void NeighborCheckJob::performAction() {
         auto timeout = KEEP_ALIVE_TIMEOUT;
         #endif
         if (now - parent.last_seen > timeout) {
-            ESP_LOGW(TAG, "Parent " MACSTR " timed out (timeout)", MAC2STR(parent.mac), timeout);
+            ESP_LOGW(TAG, "Parent " MACSTR " timed out (timeout %lu)", MAC2STR(parent.mac), timeout);
 
             // fire disconnect event
             {

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -169,7 +169,7 @@ void NeighborCheckJob::performAction() {
         auto timeout = it->rtt_est + 4*it->rtt_dev_est;
         if (now - it->last_seen > timeout) {
             auto mac = it->mac;
-            ESP_LOGW(TAG, "Direct child " MACSTR " timed out", MAC2STR(mac));
+            ESP_LOGW(TAG, "Direct child " MACSTR " timed out (timeout %d)", MAC2STR(mac), timeout);
 
             // fire disconnect event
             {
@@ -194,7 +194,7 @@ void NeighborCheckJob::performAction() {
         auto& parent = layout.getParent();
         auto timeout = parent.rtt_est + 4*parent.rtt_dev_est;
         if (now - parent.last_seen > timeout) {
-            ESP_LOGW(TAG, "Parent " MACSTR " timed out", MAC2STR(parent.mac));
+            ESP_LOGW(TAG, "Parent " MACSTR " timed out (timeout)", MAC2STR(parent.mac), timeout);
 
             // fire disconnect event
             {

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -45,8 +45,8 @@ void StatusSendJob::performAction() {
 void StatusSendJob::sendStatus() {
     ESP_LOGD(TAG, "Sending status beacons to neighbors");
     auto state = state::getState();
-    auto layout = layout::Layout::get();
-    for (const auto& child : layout.getChildren()){
+    auto& layout = layout::Layout::get();
+    for (auto& child : layout.getChildren()){
         packets::Status payload{
             .state = state,
             .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
@@ -186,7 +186,7 @@ void NeighborCheckJob::performAction() {
     // parent
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
-        auto timeout = it->rtt_est + 4*it->rtt_dev_est;
+        auto timeout = parent.rtt_est + 4*parent.rtt_dev_est;
         if (now - parent.last_seen > timeout) {
             ESP_LOGW(TAG, "Parent " MACSTR " timed out", MAC2STR(parent.mac));
 

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -45,15 +45,31 @@ void StatusSendJob::performAction() {
 void StatusSendJob::sendStatus() {
     ESP_LOGD(TAG, "Sending status beacons to neighbors");
     auto state = state::getState();
+    auto layout = layout::Layout::get();
+    for (const auto& child : layout.getChildren()){
+        packets::Status payload{
+            .state = state,
+            .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
+            .seq = child.rtt_seq | 1,
+        };
+        child.rtt_seq += 2;
+        child.last_seen_rtt = xTaskGetTickCount();
 
-    packets::Status payload{
-        .state = state,
-        .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
-    };
+        send::enqueuePayload(payload, send::DirectOnce{child.mac});
+    }
+    if (layout.hasParent()) {
+        auto& parent = layout.getParent();
+        packets::Status payload{
+            .state = state,
+            .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
+            .seq = parent.rtt_seq,
+        };
+        parent.rtt_seq += 1;
+        parent.last_seen_rtt = xTaskGetTickCount();
 
-    send::enqueuePayload(payload, send::NeighborsOnce{});
+        send::enqueuePayload(payload, send::DirectOnce{parent.mac});
+    }
 }
-
 // UnreachableTimeoutJob //
 
 TickType_t UnreachableTimeoutJob::nextActionAt() const noexcept {
@@ -146,7 +162,8 @@ void NeighborCheckJob::performAction() {
 
     // direct children
     for (auto it = layout.getChildren().begin(); it != layout.getChildren().end();) {
-        if (now - it->last_seen > KEEP_ALIVE_TIMEOUT) {
+        auto timeout = it->rtt_est + 4*it->rtt_dev_est;
+        if (now - it->last_seen > timeout) {
             auto mac = it->mac;
             ESP_LOGW(TAG, "Direct child " MACSTR " timed out", MAC2STR(mac));
 
@@ -169,7 +186,8 @@ void NeighborCheckJob::performAction() {
     // parent
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
-        if (now - parent.last_seen > KEEP_ALIVE_TIMEOUT) {
+        auto timeout = it->rtt_est + 4*it->rtt_dev_est;
+        if (now - parent.last_seen > timeout) {
             ESP_LOGW(TAG, "Parent " MACSTR " timed out", MAC2STR(parent.mac));
 
             // fire disconnect event

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -81,10 +81,14 @@ void UnreachableTimeoutJob::performAction() {
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
-
+            
+            // Send the ConnectEnd packet
+            auto payload = packets::ConnectEnd{};
+            send::enqueuePayload(payload, send::DirectOnce{parent.mac});
             layout.removeParent();
             state::setState(state::State::DISCONNECTED_FROM_PARENT);  // set state to disconnected
         }
+}
     }
 }
 
@@ -181,6 +185,9 @@ void NeighborCheckJob::performAction() {
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
 
+            // Send the ConnectEnd packet
+            auto payload = packets::ConnectEnd{};
+            send::enqueuePayload(payload, send::DirectOnce{parent.mac});
             layout.removeParent();
             state::setState(state::State::DISCONNECTED_FROM_PARENT);
         }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -277,6 +277,41 @@ void PacketHandler::handle(const MetaData& meta, const packets::RootReachable& p
     send::enqueuePayload(packets::RootUnreachable{}, send::DownstreamRetry{});
 }
 
+void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
+    if (!lastHopIsFrom(meta)) return;
+
+    auto& layout = layout::Layout::get();
+
+    if (isParent(meta.last_hop)) {
+        ESP_LOGI(TAG, "Parent " MACSTR " ended connection", MAC2STR(meta.last_hop));
+
+        {
+            meshnow_event_parent_disconnected_t parent_disconnected_event;
+            util::MacAddr& parent_mac = layout.getParent().mac;
+            std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_disconnected_event.parent_mac);
+            esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
+                           &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
+        }
+
+        layout.removeParent();
+        state::setState(state::State::DISCONNECTED_FROM_PARENT);
+        return;
+    }
+
+    if (isChild(meta.last_hop)) {
+        ESP_LOGI(TAG, "Child " MACSTR " ended connection", MAC2STR(meta.last_hop));
+
+        {
+            meshnow_event_child_disconnected_t child_disconnected_event;
+            std::copy(meta.last_hop.addr.begin(), meta.last_hop.addr.end(), child_disconnected_event.child_mac);
+            esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
+                           &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
+        }
+
+        layout.removeChild(meta.last_hop);
+    }
+}
+
 void PacketHandler::handle(const MetaData& meta, const packets::DataFragment& p) {
     if (!isNeighbor(meta.last_hop)) return;
 

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -220,6 +220,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
     event::GotConnectResponseData data{
         .parent = meta.from,
         .root = p.root,
+        .rssi = meta.rssi
     };
     event::Internal::fire(event::InternalEvent::GOT_CONNECT_RESPONSE, &data, sizeof(data));
 }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -242,7 +242,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectRequest& 
     // send reply
     ESP_LOGV(TAG, "Sending Connect Response");
     send::enqueuePayload(packets::ConnectOk{state::getRootMac()}, send::DirectOnce(meta.from));
-    #ifdef !CONFIG_USE_CONNECT_OK_ACK_MESSAGE
+    #ifndef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
         add_child(meta);
     #endif
 }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -190,25 +190,9 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectRequest& 
     if (knowsNode(meta.from)) return;
     if (!canAcceptNewChild()) return;
 
-    // add to layout
-    layout().addChild(meta.from);
-
-    ESP_LOGI(TAG, "Child " MACSTR " connected", MAC2STR(meta.from));
-
-    // fire connect event
-    {
-        meshnow_event_child_connected_t child_connected_event;
-        std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_connected_event.child_mac);
-        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_CONNECTED, &child_connected_event,
-                       sizeof(child_connected_event), portMAX_DELAY);
-    }
-
     // send reply
     ESP_LOGV(TAG, "Sending Connect Response");
     send::enqueuePayload(packets::ConnectOk{state::getRootMac()}, send::DirectOnce(meta.from));
-
-    // send routing table add packet upstream
-    send::enqueuePayload(packets::RoutingTableAdd{meta.from}, send::UpstreamRetry{});
 }
 
 void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
@@ -223,7 +207,34 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
         .rssi = meta.rssi
     };
     event::Internal::fire(event::InternalEvent::GOT_CONNECT_RESPONSE, &data, sizeof(data));
+
+    //sends a response
+    send::enqueuePayload(packets::ConnectOkAck{}, send::DirectOnce{meta.from});
 }
+
+void PacketHandler::handle(const MetaData& meta, const packets::ConnectOkAck& p) {
+    if (!lastHopIsFrom(meta)) return;
+    if (knowsNode(meta.from)) return;
+    if (!reachesRoot() || !canAcceptNewChild()) {
+        //send ConnectEnd message
+    }
+    // add to layout
+    layout().addChild(meta.from);
+
+    ESP_LOGI(TAG, "Child " MACSTR " connected", MAC2STR(meta.from));
+
+    // fire connect event
+    {
+        meshnow_event_child_connected_t child_connected_event;
+        std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_connected_event.child_mac);
+        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_CONNECTED, &child_connected_event,
+                       sizeof(child_connected_event), portMAX_DELAY);
+    }
+
+    // send routing table add packet upstream
+    send::enqueuePayload(packets::RoutingTableAdd{meta.from}, send::UpstreamRetry{});
+}
+
 
 void PacketHandler::handle(const MetaData& meta, const packets::RoutingTableAdd& p) {
     // TODO safety checks

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -178,6 +178,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
         auto rtt_dev_sample = neigh->rtt_est >= rtt_sample ? (neigh->rtt_est - rtt_sample) : (rtt_sample - neigh->rtt_est);
         neigh->rtt_est = ((neigh->rtt_est * 7) + rtt_sample)/8;
         neigh->rtt_dev_est = ((neigh->rtt_dev_est * 3) + rtt_dev_sample)/4;
+        ESP_LOGV(TAG, "new rtt sample %d, rtt estimate %d and rtt dev estimate %dcode ", rtt_sample, neigh->rtt_est, neigh->rtt_dev_est);
     }
     return;
 }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -282,7 +282,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
 
     auto& layout = layout::Layout::get();
 
-    if (isParent(meta.last_hop)) {
+    if (isParent(meta.from)) {
         ESP_LOGI(TAG, "Parent " MACSTR " ended connection", MAC2STR(meta.last_hop));
 
         {
@@ -298,17 +298,17 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
         return;
     }
 
-    if (isChild(meta.last_hop)) {
-        ESP_LOGI(TAG, "Child " MACSTR " ended connection", MAC2STR(meta.last_hop));
+    if (isChild(meta.from)) {
+        ESP_LOGI(TAG, "Child " MACSTR " ended connection", MAC2STR(meta.from));
 
         {
             meshnow_event_child_disconnected_t child_disconnected_event;
-            std::copy(meta.last_hop.addr.begin(), meta.last_hop.addr.end(), child_disconnected_event.child_mac);
+            std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_disconnected_event.child_mac);
             esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
                            &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
         }
 
-        layout.removeChild(meta.last_hop);
+        layout.removeChild(meta.from);
     }
 }
 

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -125,6 +125,24 @@ inline bool disconnected() {
     }
 }
 
+inline void add_child(const MetaData& meta) {
+    // add to layout
+    layout().addChild(meta.from);
+
+    ESP_LOGI(TAG, "Child " MACSTR " connected", MAC2STR(meta.from));
+
+    // fire connect event
+    {
+        meshnow_event_child_connected_t child_connected_event;
+        std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_connected_event.child_mac);
+        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_CONNECTED, &child_connected_event,
+                       sizeof(child_connected_event), portMAX_DELAY);
+    }
+
+    // send routing table add packet upstream
+    send::enqueuePayload(packets::RoutingTableAdd{meta.from}, send::UpstreamRetry{});
+}
+
 }  // namespace
 
 // HANDLERS //
@@ -158,6 +176,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
             }
         }
     }
+    #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
     auto* neigh = layout.hasChild(meta.from) ? &layout.getChild(meta.from) : 
                     layout.hasParent() && layout.getParent().mac == meta.from ? &layout.getParent() :
                     nullptr;
@@ -165,6 +184,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
     if (neigh == nullptr) return;
 
     if ((p.seq&1) == 1) {
+        //odd means seq, must reply with an ack
         auto state = state::getState();
         packets::Status response{
             .state = state,
@@ -173,14 +193,20 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
         };
         send::enqueuePayload(response, send::DirectOnce{meta.from});
     } else {
+        //even means ack, must check the sequence match and compute new rtt est
         if (neigh->rtt_seq != p.seq) return;
         auto rtt_sample = xTaskGetTickCount() - neigh->last_seen_rtt;
         auto rtt_dev_sample = neigh->rtt_est >= rtt_sample ? (neigh->rtt_est - rtt_sample) : (rtt_sample - neigh->rtt_est);
         neigh->rtt_est = ((neigh->rtt_est * 7) + rtt_sample)/8;
+        //sometimes we have little precision problem with for instance rtt_est = 0 and rtt_sample = 1
+        neigh->rtt_est = neigh->rtt_est == 0 ? 1 : neigh->rtt_est;
+        //same precaution here
         neigh->rtt_dev_est = ((neigh->rtt_dev_est * 3) + rtt_dev_sample)/4;
+        neigh->rtt_dev_est = neigh->rtt_dev_est == 0 ? 1 : neigh->rtt_est;
         ESP_LOGV(TAG, "new rtt sample %d, rtt estimate %d and rtt dev estimate %dcode ", rtt_sample, neigh->rtt_est, neigh->rtt_dev_est);
     }
     return;
+    #endif
 }
 
 void PacketHandler::handle(const MetaData& meta, const packets::SearchProbe& p) {
@@ -216,6 +242,9 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectRequest& 
     // send reply
     ESP_LOGV(TAG, "Sending Connect Response");
     send::enqueuePayload(packets::ConnectOk{state::getRootMac()}, send::DirectOnce(meta.from));
+    #ifdef !CONFIG_USE_CONNECT_OK_ACK_MESSAGE
+        add_child(meta);
+    #endif
 }
 
 void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
@@ -231,10 +260,13 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
     };
     event::Internal::fire(event::InternalEvent::GOT_CONNECT_RESPONSE, &data, sizeof(data));
 
+    #ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
     //sends a response
     send::enqueuePayload(packets::ConnectOkAck{}, send::DirectOnce{meta.from});
+    #endif
 }
 
+#ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
 void PacketHandler::handle(const MetaData& meta, const packets::ConnectOkAck& p) {
     if (!lastHopIsFrom(meta)) return;
     if (knowsNode(meta.from)) return;
@@ -243,23 +275,9 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOkAck& p)
         ESP_LOGI(TAG, "Received connect acknowledge but cannot accept it anymore : send connect end");
         return;
     }
-    // add to layout
-    layout().addChild(meta.from);
-
-    ESP_LOGI(TAG, "Child " MACSTR " connected", MAC2STR(meta.from));
-
-    // fire connect event
-    {
-        meshnow_event_child_connected_t child_connected_event;
-        std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_connected_event.child_mac);
-        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_CONNECTED, &child_connected_event,
-                       sizeof(child_connected_event), portMAX_DELAY);
-    }
-
-    // send routing table add packet upstream
-    send::enqueuePayload(packets::RoutingTableAdd{meta.from}, send::UpstreamRetry{});
+    add_child(meta);
 }
-
+#endif
 
 void PacketHandler::handle(const MetaData& meta, const packets::RoutingTableAdd& p) {
     // TODO safety checks
@@ -312,7 +330,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::RootReachable& p
     // forward to all children
     send::enqueuePayload(packets::RootUnreachable{}, send::DownstreamRetry{});
 }
-
+#ifdef CONFIG_USE_CONNECT_END_MESSAGE
 void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
     if (!lastHopIsFrom(meta)) return;
 
@@ -347,6 +365,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
         layout.removeChild(meta.from);
     }
 }
+#endif
 
 void PacketHandler::handle(const MetaData& meta, const packets::DataFragment& p) {
     if (!isNeighbor(meta.last_hop)) return;

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -137,27 +137,49 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
     // is parent?
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
-        if (parent.mac != meta.from) return;
+        if (parent.mac == meta.from) {
 
-        switch (p.state) {
-            case state::State::DISCONNECTED_FROM_PARENT:
-            case state::State::CONNECTED_TO_PARENT: {
-                state::setState(state::State::CONNECTED_TO_PARENT);
-                break;
-            }
-            case state::State::REACHES_ROOT: {
-                // this should never be the case, but we never know with malicious packets
-                if (!p.root.has_value()) return;
+            switch (p.state) {
+                case state::State::DISCONNECTED_FROM_PARENT:
+                case state::State::CONNECTED_TO_PARENT: {
+                    state::setState(state::State::CONNECTED_TO_PARENT);
+                    break;
+                }
+                case state::State::REACHES_ROOT: {
+                    // this should never be the case, but we never know with malicious packets
+                    if (!p.root.has_value()) break;
 
-                // set root mac
-                state::setRootMac(p.root.value());
-                // set state
-                state::setState(state::State::REACHES_ROOT);
-                break;
+                    // set root mac
+                    state::setRootMac(p.root.value());
+                    // set state
+                    state::setState(state::State::REACHES_ROOT);
+                    break;
+                }
             }
         }
-        return;
     }
+
+    layout::Neighbor neigh;
+    if (layout.hasChild(meta.from)) {
+        neigh = layout.getChild(meta.from);
+    } else if (layout.hasParent()) {
+        neigh = layout.getParent();
+    }
+    if (p.seq&1 == 1) {
+        packets::Status response{
+            .state = state::getState(),
+            .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
+            .seq = (p.seq ^ 1) + 2,
+        }
+        send::enqueuePayload(response, send::DirectOnce{meta.from});
+    } else {
+        if (neigh.rtt_seq != p.seq) return;
+        auto rtt_sample = xTaskGetTickCount() - neigh.last_seen_rtt;
+        auto rtt_dev_sample = neigh.rtt_est >= rtt_sample ? (neigh.rtt_est - rtt_sample) : (rtt_sample - neigh.rtt_est)
+        neigh.rtt_est = ((neigh.rtt_est * 7) + rtt_sample)/8
+        neigh.rtt_dev_est = ((neigh.rtt_dev_est * 3) + rtt_dev_sample)/4
+    }
+    return;
 }
 
 void PacketHandler::handle(const MetaData& meta, const packets::SearchProbe& p) {

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -134,18 +134,11 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
 
     auto& layout = layout::Layout::get();
 
-    // is child?
-    if (layout.hasChild(meta.from)) {
-        auto& child = layout.getChild(meta.from);
-        child.last_seen = xTaskGetTickCount();
-    }
-
     // is parent?
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
         if (parent.mac != meta.from) return;
 
-        parent.last_seen = xTaskGetTickCount();
         switch (p.state) {
             case state::State::DISCONNECTED_FROM_PARENT:
             case state::State::CONNECTED_TO_PARENT: {

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -158,26 +158,26 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
             }
         }
     }
+    auto* neigh = layout.hasChild(meta.from) ? &layout.getChild(meta.from) : 
+                    layout.hasParent() && layout.getParent().mac == meta.from ? &layout.getParent() :
+                    nullptr;
+                    
+    if (neigh == nullptr) return;
 
-    layout::Neighbor neigh;
-    if (layout.hasChild(meta.from)) {
-        neigh = layout.getChild(meta.from);
-    } else if (layout.hasParent()) {
-        neigh = layout.getParent();
-    }
-    if (p.seq&1 == 1) {
+    if ((p.seq&1) == 1) {
+        auto state = state::getState();
         packets::Status response{
-            .state = state::getState(),
+            .state = state,
             .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
             .seq = (p.seq ^ 1) + 2,
-        }
+        };
         send::enqueuePayload(response, send::DirectOnce{meta.from});
     } else {
-        if (neigh.rtt_seq != p.seq) return;
-        auto rtt_sample = xTaskGetTickCount() - neigh.last_seen_rtt;
-        auto rtt_dev_sample = neigh.rtt_est >= rtt_sample ? (neigh.rtt_est - rtt_sample) : (rtt_sample - neigh.rtt_est)
-        neigh.rtt_est = ((neigh.rtt_est * 7) + rtt_sample)/8
-        neigh.rtt_dev_est = ((neigh.rtt_dev_est * 3) + rtt_dev_sample)/4
+        if (neigh->rtt_seq != p.seq) return;
+        auto rtt_sample = xTaskGetTickCount() - neigh->last_seen_rtt;
+        auto rtt_dev_sample = neigh->rtt_est >= rtt_sample ? (neigh->rtt_est - rtt_sample) : (rtt_sample - neigh->rtt_est);
+        neigh->rtt_est = ((neigh->rtt_est * 7) + rtt_sample)/8;
+        neigh->rtt_dev_est = ((neigh->rtt_dev_est * 3) + rtt_dev_sample)/4;
     }
     return;
 }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -238,7 +238,9 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOkAck& p)
     if (!lastHopIsFrom(meta)) return;
     if (knowsNode(meta.from)) return;
     if (!reachesRoot() || !canAcceptNewChild()) {
-        //send ConnectEnd message
+        send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce{meta.from});
+        ESP_LOGI(TAG, "Received connect acknowledge but cannot accept it anymore : send connect end");
+        return;
     }
     // add to layout
     layout().addChild(meta.from);

--- a/meshnow/src/job/packet_handler.hpp
+++ b/meshnow/src/job/packet_handler.hpp
@@ -30,12 +30,16 @@ class PacketHandler {
     static void handle(const MetaData& meta, const packets::SearchReply& p);
     static void handle(const MetaData& meta, const packets::ConnectRequest& p);
     static void handle(const MetaData& meta, const packets::ConnectOk& p);
+    #ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
     static void handle(const MetaData& meta, const packets::ConnectOkAck& p);
+    #endif
     static void handle(const MetaData& meta, const packets::RoutingTableAdd& p);
     static void handle(const MetaData& meta, const packets::RoutingTableRemove& p);
     static void handle(const MetaData& meta, const packets::RootUnreachable& p);
     static void handle(const MetaData& meta, const packets::RootReachable& p);
+    #ifdef CONFIG_USE_CONNECT_END_MESSAGE
     static void handle(const MetaData& meta, const packets::ConnectEnd& p);
+    #endif
     static void handle(const MetaData& meta, const packets::DataFragment& p);
     static void handle(const MetaData& meta, const packets::CustomData& p);
 };

--- a/meshnow/src/job/packet_handler.hpp
+++ b/meshnow/src/job/packet_handler.hpp
@@ -30,6 +30,7 @@ class PacketHandler {
     static void handle(const MetaData& meta, const packets::SearchReply& p);
     static void handle(const MetaData& meta, const packets::ConnectRequest& p);
     static void handle(const MetaData& meta, const packets::ConnectOk& p);
+    static void handle(const MetaData& meta, const packets::ConnectOkAck& p);
     static void handle(const MetaData& meta, const packets::RoutingTableAdd& p);
     static void handle(const MetaData& meta, const packets::RoutingTableRemove& p);
     static void handle(const MetaData& meta, const packets::RootUnreachable& p);

--- a/meshnow/src/job/packet_handler.hpp
+++ b/meshnow/src/job/packet_handler.hpp
@@ -34,6 +34,7 @@ class PacketHandler {
     static void handle(const MetaData& meta, const packets::RoutingTableRemove& p);
     static void handle(const MetaData& meta, const packets::RootUnreachable& p);
     static void handle(const MetaData& meta, const packets::RootReachable& p);
+    static void handle(const MetaData& meta, const packets::ConnectEnd& p);
     static void handle(const MetaData& meta, const packets::DataFragment& p);
     static void handle(const MetaData& meta, const packets::CustomData& p);
 };

--- a/meshnow/src/layout.cpp
+++ b/meshnow/src/layout.cpp
@@ -56,7 +56,10 @@ Neighbor& Layout::getParent() { return parent_.value(); }
 
 void Layout::setParent(const util::MacAddr& mac) { parent_.emplace(mac); }
 
-void Layout::removeParent() { parent_.reset(); }
+void Layout::removeParent() { 
+    
+    parent_.reset(); 
+}
 
 bool Layout::hasChild(const util::MacAddr& mac) const {
     for (const auto& child : children_) {

--- a/meshnow/src/layout.hpp
+++ b/meshnow/src/layout.hpp
@@ -26,10 +26,12 @@ struct Node {
 struct Neighbor : Node {
     using Node::Node;
     TickType_t last_seen{xTaskGetTickCount()};
+    #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
     TickType_t last_seen_rtt{0};
     TickType_t rtt_est{pdMS_TO_TICKS(CONFIG_KEEP_ALIVE_TIMEOUT)};
     TickType_t rtt_dev_est{0};
     uint32_t rtt_seq{0};
+    #endif
 };
 
 struct Child : Neighbor {

--- a/meshnow/src/layout.hpp
+++ b/meshnow/src/layout.hpp
@@ -26,6 +26,10 @@ struct Node {
 struct Neighbor : Node {
     using Node::Node;
     TickType_t last_seen{xTaskGetTickCount()};
+    TickType_t last_seen_rtt{0};
+    TickType_t rtt_est{pdMS_TO_TICKS(CONFIG_KEEP_ALIVE_TIMEOUT)};
+    TickType_t rtt_dev_est{0};
+    uint32_t rtt_seq{0};
 };
 
 struct Child : Neighbor {

--- a/meshnow/src/packets.cpp
+++ b/meshnow/src/packets.cpp
@@ -106,6 +106,7 @@ static void serialize(S& s, Status& p) {
     s.value1b(p.state);
     // TODO optimize with custom extension
     s.ext(p.root, bitsery::ext::StdOptional{});
+    s.value4b(p.seq);
 }
 
 template <typename S>

--- a/meshnow/src/packets.cpp
+++ b/meshnow/src/packets.cpp
@@ -129,6 +129,11 @@ static void serialize(S& s, ConnectOk& p) {
 }
 
 template <typename S>
+static void serialize(S&, ConnectOkAck&) {
+    //no data
+}
+
+template <typename S>
 static void serialize(S& s, RoutingTableAdd& p) {
     s.object(p.entry);
 }

--- a/meshnow/src/packets.cpp
+++ b/meshnow/src/packets.cpp
@@ -106,18 +106,21 @@ static void serialize(S& s, Status& p) {
     s.value1b(p.state);
     // TODO optimize with custom extension
     s.ext(p.root, bitsery::ext::StdOptional{});
+    #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
     s.value4b(p.seq);
+    #endif
 }
 
 template <typename S>
 static void serialize(S&, SearchProbe&) {
     // no data
 }
-
+#ifdef CONFIG_USE_CONNECT_END_MESSAGE
 template <typename S>
 static void serialize(S&, ConnectEnd&) {
     // no data
 }
+#endif
 
 
 template <typename S>
@@ -134,11 +137,12 @@ template <typename S>
 static void serialize(S& s, ConnectOk& p) {
     s.object(p.root);
 }
-
+#ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
 template <typename S>
 static void serialize(S&, ConnectOkAck&) {
     //no data
 }
+#endif
 
 template <typename S>
 static void serialize(S& s, RoutingTableAdd& p) {

--- a/meshnow/src/packets.cpp
+++ b/meshnow/src/packets.cpp
@@ -114,6 +114,12 @@ static void serialize(S&, SearchProbe&) {
 }
 
 template <typename S>
+static void serialize(S&, ConnectEnd&) {
+    // no data
+}
+
+
+template <typename S>
 static void serialize(S&, SearchReply&) {
     // no data
 }

--- a/meshnow/src/packets.hpp
+++ b/meshnow/src/packets.hpp
@@ -13,6 +13,7 @@ namespace meshnow::packets {
 struct Status {
     state::State state;
     std::optional<util::MacAddr> root;
+    uint32_t seq;
 };
 
 struct SearchProbe {};

--- a/meshnow/src/packets.hpp
+++ b/meshnow/src/packets.hpp
@@ -56,8 +56,10 @@ struct CustomData {
     util::Buffer data;
 };
 
+struct ConnectEnd {};
+
 using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, RoutingTableAdd,
-                             RoutingTableRemove, RootUnreachable, RootReachable, DataFragment, CustomData>;
+                             RoutingTableRemove, RootUnreachable, RootReachable, DataFragment, CustomData, ConnectEnd>;
 
 struct Packet {
     uint32_t id;

--- a/meshnow/src/packets.hpp
+++ b/meshnow/src/packets.hpp
@@ -25,6 +25,8 @@ struct ConnectOk {
     util::MacAddr root;
 };
 
+struct ConnectOkAck {};
+
 struct RoutingTableAdd {
     util::MacAddr entry;
 };
@@ -56,8 +58,9 @@ struct CustomData {
     util::Buffer data;
 };
 
-using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, RoutingTableAdd,
-                             RoutingTableRemove, RootUnreachable, RootReachable, DataFragment, CustomData>;
+using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, ConnectOkAck, 
+                             RoutingTableAdd, RoutingTableRemove, RootUnreachable, RootReachable, 
+                             DataFragment, CustomData>;
 
 struct Packet {
     uint32_t id;

--- a/meshnow/src/packets.hpp
+++ b/meshnow/src/packets.hpp
@@ -13,7 +13,9 @@ namespace meshnow::packets {
 struct Status {
     state::State state;
     std::optional<util::MacAddr> root;
+#ifdef CONFIG_USE_RTT_FOR_TIMEOUT
     uint32_t seq;
+#endif
 };
 
 struct SearchProbe {};
@@ -26,9 +28,13 @@ struct ConnectOk {
     util::MacAddr root;
 };
 
+#ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
 struct ConnectOkAck {};
+#endif
 
+#ifdef CONFIG_USE_CONNECT_END_MESSAGE
 struct ConnectEnd {};
+#endif
 
 
 struct RoutingTableAdd {
@@ -63,9 +69,16 @@ struct CustomData {
 };
 
 
-using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, ConnectOkAck, 
-                             ConnectEnd, RoutingTableAdd, RoutingTableRemove, RootUnreachable, RootReachable, 
-                             DataFragment, CustomData>;
+using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, 
+                            RoutingTableAdd, RoutingTableRemove, RootUnreachable, RootReachable, 
+                            DataFragment,
+                            #ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
+                            ConnectOkAck,
+                            #endif
+                            #ifdef CONFIG_USE_CONNECT_END_MESSAGE
+                            ConnectEnd,
+                            #endif
+                            CustomData>;
 
 struct Packet {
     uint32_t id;

--- a/meshnow/src/receive/queue.cpp
+++ b/meshnow/src/receive/queue.cpp
@@ -16,6 +16,8 @@ void deinit() { queue = util::Queue<Item>{}; }
 
 void push(Item&& item) { queue.push_back(std::move(item), QUEUE_TIMEOUT); }
 
+void push_front(Item&& item) { queue.push_front(std::move(item), QUEUE_TIMEOUT); }
+
 std::optional<Item> pop(TickType_t timeout) { return queue.pop(timeout); }
 
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/queue.cpp
+++ b/meshnow/src/receive/queue.cpp
@@ -1,23 +1,71 @@
 #include "queue.hpp"
+#include <optional>
 
 #include "util/queue.hpp"
 
 static constexpr auto QUEUE_TIMEOUT{pdMS_TO_TICKS(100)};
+static constexpr std::size_t PRIORITY_LEVELS{3};
+static constexpr std::size_t PEOPLE_PER_LEVEL{2};
 static constexpr auto QUEUE_SIZE{128};
 // TODO QUEUE_SIZE has to be higher so not to get deadlocks! FIND A REAL SOLUTION!
 
 namespace meshnow::receive {
 
-static util::Queue<Item> queue;
+static std::array<util::Queue<Item>, PRIORITY_LEVELS> priority_queues;
+//this array helps to insure some amount of fairness between priority levels 
+static std::array<std::size_t, PRIORITY_LEVELS> crowded_timeouts;
 
-esp_err_t init() { return queue.init(QUEUE_SIZE); }
+esp_err_t init() { 
+    for (auto& queue : priority_queues) {
+        auto err = queue.init(QUEUE_SIZE);
+        if (err != ESP_OK) return err;
+    }
+    for (auto i = 0; i < PRIORITY_LEVELS; i++) {
+        crowded_timeouts[i] = (PRIORITY_LEVELS - i)*PEOPLE_PER_LEVEL;
+    }
+    return ESP_OK;
+}
 
-void deinit() { queue = util::Queue<Item>{}; }
+void deinit() { 
+    for (auto& queue : priority_queues) {
+        queue = util::Queue<Item>{};
+    }
+}
 
-void push(Item&& item) { queue.push_back(std::move(item), QUEUE_TIMEOUT); }
+void push(Item&& item) { priority_queues[0].push_back(std::move(item), QUEUE_TIMEOUT); }
 
-void push_front(Item&& item) { queue.push_front(std::move(item), QUEUE_TIMEOUT); }
+void push(Item&& item, p_level level) {
+    if (level < PRIORITY_LEVELS) {
+        priority_queues[level].push_back(std::move(item), QUEUE_TIMEOUT);
+    } else {
+        //the given priority level is higher than the max priority defined in PRIORITY_LEVELS
+        //hence we push this element at the front of the biggest priority subqueue
+        priority_queues[PRIORITY_LEVELS-1].push_front(std::move(item), QUEUE_TIMEOUT);
+    }
+}
+//std::optional<Item> pop(TickType_t timeout) { return priority_queue[0].pop(timeout); }
 
-std::optional<Item> pop(TickType_t timeout) { return queue.pop(timeout); }
+std::optional<Item> pop(TickType_t timeout) {    
+    for (int i = PRIORITY_LEVELS - 1; i >= 0; --i) {
+        //we first go to the high priority queues that still have some
+        //messages to be poped
+        if (priority_queues[i].items_waiting() && crowded_timeouts[i]-- > 0) {
+            //if the crowded_timeouts[i] counter is >= 0, then fetches the elements from the queue
+            return priority_queues[i].pop(timeout);
+        } else {
+            //Here, it could happen that 
+            //  1) we're here because priority_queues[i] was empty. Hence we allow it to have a init value counter
+            //  2) we're here because crowded_timouts[i] has reached 0. This means that, over the last 
+            //      (PRIORITY_LEVELS-i)*PEOPLE_PER_LEVEL pop() calls, the poped item was coming from 
+            //      the queue i. This is too much and i needs to let lower priorities be popped too.
+            //Note that, the higher the priority, the lower the crowded_timouts threshold. This allows to have a 
+            //fairer popping system.
+            crowded_timeouts[i] = (PRIORITY_LEVELS - i)*PEOPLE_PER_LEVEL;
+        }
+    }
+    //just a fallback if very queue is empty
+    return priority_queues[PRIORITY_LEVELS-1].pop(timeout);
+}
 
 }  // namespace meshnow::receive
+

--- a/meshnow/src/receive/queue.cpp
+++ b/meshnow/src/receive/queue.cpp
@@ -4,8 +4,8 @@
 #include "util/queue.hpp"
 
 static constexpr auto QUEUE_TIMEOUT{pdMS_TO_TICKS(100)};
-static constexpr std::size_t PRIORITY_LEVELS{3};
-static constexpr std::size_t PEOPLE_PER_LEVEL{2};
+static constexpr std::size_t PRIORITY_LEVELS{CONFIG_RECEIVER_PRIORITY_QUEUE_LEVELS};
+static constexpr std::size_t PEOPLE_PER_LEVEL{CONFIG_MESSAGES_PER_PRIORITY_LEVEL};
 static constexpr auto QUEUE_SIZE{128};
 // TODO QUEUE_SIZE has to be higher so not to get deadlocks! FIND A REAL SOLUTION!
 
@@ -32,7 +32,7 @@ void deinit() {
     }
 }
 
-void push(Item&& item) { priority_queues[0].push_back(std::move(item), QUEUE_TIMEOUT); }
+void push(Item&& item) { priority_queues[PRIORITY_LEVELS-1].push_back(std::move(item), QUEUE_TIMEOUT); }
 
 void push(Item&& item, p_level level) {
     if (level < PRIORITY_LEVELS) {

--- a/meshnow/src/receive/queue.hpp
+++ b/meshnow/src/receive/queue.hpp
@@ -45,7 +45,7 @@ void deinit();
  *
  * @param item Item to push.
  *
- * @warning the pushed the item with the least
+ * @warning the pushed the item with the highest
  * priority
  */
 void push(Item&& item);

--- a/meshnow/src/receive/queue.hpp
+++ b/meshnow/src/receive/queue.hpp
@@ -23,6 +23,12 @@ struct Item {
     int rssi;
     packets::Packet packet;
 };
+/**
+ * A type defintion to represent priority level
+ *
+ * HIGHER is BETTER
+ */
+typedef std::size_t p_level;
 
 /**
  * Initializes receive queue.
@@ -38,22 +44,32 @@ void deinit();
  * Pushes a new item to the receive queue.
  *
  * @param item Item to push.
+ *
+ * @warning the pushed the item with the least
+ * priority
  */
 void push(Item&& item);
 
 /**
- * Pushed a new item to to top of the receive queue
+ * Pushes a new item at a certain priority level
  *
- * @param Item Item to push
+ * @param item Item to push
+ * @param level Priority level of the item
  */
-void push_front(Item&& item);
-
+void push(Item&& item, p_level level);
 /**
  * Pops an item from the receive queue.
  *
  * @param item Item to pop.
  * @param timeout Timeout in ticks.
+ *
+ * @note When the queue has some non-trivial
+ * priorities, this function fetches the 
+ * highest-priority element. 
+ * To prevent items with low priority to stay
+ * in the queue for ever, a mechanism is set so
+ * that once in a while low priority elements get
+ * fetched.
  */
 std::optional<Item> pop(TickType_t timeout);
-
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/queue.hpp
+++ b/meshnow/src/receive/queue.hpp
@@ -42,6 +42,13 @@ void deinit();
 void push(Item&& item);
 
 /**
+ * Pushed a new item to to top of the receive queue
+ *
+ * @param Item Item to push
+ */
+void push_front(Item&& item);
+
+/**
  * Pops an item from the receive queue.
  *
  * @param item Item to pop.

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -71,11 +71,11 @@ void handle(Item&& item, const PacketType&) {
             ESP_LOGD(TAG, "Receiving CONNECT_OK : pushing at level %d", CONNECT_OK_LEVEL);
             return CONNECT_OK_LEVEL;
         }
-        else if constexpr (std::same_as<PacketType, packets::ConnectOkAck) {
+        else if constexpr (std::same_as<PacketType, packets::ConnectOkAck>) {
             ESP_LOGD(TAG, "Receiving CONNECT_OK_ACK : pushing at level %d", CONNECT_OK_ACK_LEVEL);
             return CONNECT_OK_ACK_LEVEL;
         }
-        else if constexpr (std::same_as<PacketType, packets::ConnectEnd) {
+        else if constexpr (std::same_as<PacketType, packets::ConnectEnd>) {
             ESP_LOGD(TAG, "Receiving CONNECT_ENT : pushing at level %d", CONNECT_END_LEVEL);
             return CONNECT_END_LEVEL;
         }
@@ -101,7 +101,7 @@ void handle(Item&& item, const PacketType&) {
         }
         else {
             ESP_LOGD(TAG, "Receiving UNKNOW : pushing at level 0\n");
-            return 0;
+            return p_level{0};
         }
     }();
     ESP_LOGD(TAG, "Pushing message to level %d", level);

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -39,8 +39,12 @@ constexpr meshnow::receive::p_level SEARCH_PROBE_LEVEL = CONFIG_SEARCH_PROBE_MES
 constexpr meshnow::receive::p_level SEARCH_REPLY_LEVEL = CONFIG_SEARCH_REPLY_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_REQUEST_LEVEL = CONFIG_CONNECT_REQUEST_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_OK_LEVEL = CONFIG_CONNECT_OK_MESSAGE_LEVEL;
+#ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
 constexpr meshnow::receive::p_level CONNECT_OK_ACK_LEVEL = CONFIG_CONNECT_OK_ACK_MESSAGE_LEVEL;
+#endif
+#ifdef CONFIG_USE_CONNECT_END_MESSAGE
 constexpr meshnow::receive::p_level CONNECT_END_LEVEL = CONFIG_CONNECT_END_MESSAGE_LEVEL;
+#endif
 constexpr meshnow::receive::p_level ROUTING_TABLE_ADD_LEVEL = CONFIG_ROUTING_TABLE_ADD_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROUTING_TABLE_REMOVE_LEVEL = CONFIG_ROUTING_TABLE_REMOVE_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROOT_UNREACHABLE_LEVEL = CONFIG_ROOT_UNREACHABLE_MESSAGE_LEVEL;
@@ -71,14 +75,18 @@ void handle(Item&& item, const PacketType&) {
             ESP_LOGD(TAG, "Receiving CONNECT_OK : pushing at level %d", CONNECT_OK_LEVEL);
             return CONNECT_OK_LEVEL;
         }
+        #ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
         else if constexpr (std::same_as<PacketType, packets::ConnectOkAck>) {
             ESP_LOGD(TAG, "Receiving CONNECT_OK_ACK : pushing at level %d", CONNECT_OK_ACK_LEVEL);
             return CONNECT_OK_ACK_LEVEL;
         }
+        #endif
+        #ifdef CONFIG_USE_CONNECT_END_MESSAGE
         else if constexpr (std::same_as<PacketType, packets::ConnectEnd>) {
             ESP_LOGD(TAG, "Receiving CONNECT_ENT : pushing at level %d", CONNECT_END_LEVEL);
             return CONNECT_END_LEVEL;
         }
+        #endif
         else if constexpr (std::same_as<PacketType, packets::RoutingTableAdd>) {
             ESP_LOGD(TAG, "Receiving ROUTING_ADD_TABLE : pushing at level %d", ROUTING_TABLE_ADD_LEVEL);
             return ROUTING_TABLE_ADD_LEVEL;

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -4,6 +4,27 @@
 
 #include "packets.hpp"
 #include "queue.hpp"
+#include "layout.hpp"
+
+namespace  {
+void update_last_seen(const meshnow::util::MacAddr mac) {
+    auto& layout = meshnow::layout::Layout::get();
+
+        // is child?
+    if (layout.hasChild(mac)) {
+        auto& child = layout.getChild(mac);
+        child.last_seen = xTaskGetTickCount();
+    }
+
+    // is parent?
+    if (layout.hasParent()) {
+        auto& parent = layout.getParent();
+        if (parent.mac != mac) return;
+
+        parent.last_seen = xTaskGetTickCount();
+    }
+}
+}
 
 namespace meshnow::receive {
 
@@ -11,29 +32,34 @@ namespace {
 constexpr auto TAG = CREATE_TAG("Receiver");
 }
 
-void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
-    // convert raw data pointer into buffer (vector) for deserialization TODO avoid this
-    std::vector<uint8_t> buffer(data, data + data_len);
+void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info,
+                               const uint8_t *data, int data_len) {
+  // convert raw data pointer into buffer (vector) for deserialization TODO
+  // avoid this
+  std::vector<uint8_t> buffer(data, data + data_len);
 
-    // deserialize
-    auto packet = packets::deserialize(buffer);
+  // deserialize
+  auto packet = packets::deserialize(buffer);
 
-    // if deserialization failed, ignore
-    // could happen because of interference with connecting to a router
-    if (!packet) {
-        ESP_LOGV(TAG, "Failed to deserialize packet!");
-        return;
-    }
+  // if deserialization failed, ignore
+  // could happen because of interference with connecting to a router
+  if (!packet) {
+    ESP_LOGV(TAG, "Failed to deserialize packet!");
+    return;
+  }
 
-    // create item
-    Item item{
-        util::MacAddr(esp_now_info->src_addr),
-        esp_now_info->rx_ctrl->rssi,
-        std::move(*packet),
-    };
+  // update last seen
+  update_last_seen(util::MacAddr(esp_now_info->src_addr));
 
-    // push item to queue
-    push(std::move(item));
+  // create item
+  Item item{
+      util::MacAddr(esp_now_info->src_addr),
+      esp_now_info->rx_ctrl->rssi,
+      std::move(*packet),
+  };
+
+  // push item to queue
+  push(std::move(item));
 }
 
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -35,7 +35,7 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
 
     if (std::holds_alternative<packets::Status>(item.packet.payload)) {
         // prioritary message : push item to the front of the queue
-        push_front(std::move(item));
+        push(std::move(item), 10);
     } else {
         // not a prioritary message : push item to the end of the queue
         push(std::move(item));

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -1,6 +1,7 @@
 #include "receiver.hpp"
 
 #include <esp_log.h>
+#include <utility>
 
 #include "packets.hpp"
 #include "queue.hpp"
@@ -32,8 +33,13 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
         std::move(*packet),
     };
 
-    // push item to queue
-    push(std::move(item));
+    if (std::holds_alternative<packets::Status>(item.packet.payload)) {
+        // prioritary message : push item to the front of the queue
+        push_front(std::move(item));
+    } else {
+        // not a prioritary message : push item to the end of the queue
+        push(std::move(item));
+    }
 }
 
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -2,16 +2,46 @@
 
 #include <esp_log.h>
 #include <utility>
+#include <variant>
 
 #include "packets.hpp"
 #include "queue.hpp"
+#include "state.hpp"
+#include "util/mac.hpp"
 
 namespace meshnow::receive {
 
 namespace {
 constexpr auto TAG = CREATE_TAG("Receiver");
+constexpr meshnow::receive::p_level STATUS_LEVEL = CONFIG_STATUS_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level SEARCH_PROVE_LEVEL = CONFIG_SEARCH_PROBE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level SEARCH_REPLY_LEVEL = CONFIG_SEARCH_REPLY_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CONNECT_REQUEST_LEVEL = CONFIG_CONNECT_REQUEST_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CONNECT_OK_LEVEL = CONFIG_CONNECT_OK_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level ROUTING_TABLE_ADD_LEVEL = CONFIG_ROUTING_TABLE_ADD_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level ROUTING_TABLE_REMOVE_LEVEL = CONFIG_ROUTING_TABLE_REMOVE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level ROOT_UNREACHABLE_LEVEL = CONFIG_ROOT_UNREACHABLE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level ROOT_REACHABLE_LEVEL = CONFIG_ROOT_REACHABLE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level DATA_FRAGMENT_LEVEL = CONFIG_DATA_FRAGMENT_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CUSTOM_DATA_LEVEL = CONFIG_CUSTOM_DATA_MESSAGE_LEVEL;
 }
+template<typename PacketType>
+void handle(Item&& item, const PacketType&) {
+    constexpr p_level level =
+        std::same_as<PacketType, packets::Status>             ? STATUS_LEVEL :
+        std::same_as<PacketType, packets::SearchProbe>        ? SEARCH_PROVE_LEVEL :
+        std::same_as<PacketType, packets::SearchReply>        ? SEARCH_REPLY_LEVEL :
+        std::same_as<PacketType, packets::ConnectRequest>     ? CONNECT_REQUEST_LEVEL :
+        std::same_as<PacketType, packets::ConnectOk>          ? CONNECT_OK_LEVEL :
+        std::same_as<PacketType, packets::RoutingTableAdd>    ? ROUTING_TABLE_ADD_LEVEL :
+        std::same_as<PacketType, packets::RoutingTableRemove> ? ROUTING_TABLE_REMOVE_LEVEL :
+        std::same_as<PacketType, packets::RootUnreachable>    ? ROOT_UNREACHABLE_LEVEL :
+        std::same_as<PacketType, packets::RootReachable>      ? ROOT_REACHABLE_LEVEL :
+        std::same_as<PacketType, packets::DataFragment>       ? DATA_FRAGMENT_LEVEL :
+                                                               0;
 
+    push(std::move(item), level);
+}
 void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
     // convert raw data pointer into buffer (vector) for deserialization TODO avoid this
     std::vector<uint8_t> buffer(data, data + data_len);
@@ -32,12 +62,10 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
         esp_now_info->rx_ctrl->rssi,
         std::move(*packet),
     };
-
-    if (std::holds_alternative<packets::Status>(item.packet.payload)) {
-        // prioritary message : push item to the front of the queue
-        push(std::move(item), 10);
+    if (item.packet.to == state::getThisMac() || (item.packet.to == util::MacAddr::root() && state::isRoot())) {
+        handle(std::move(item), item.packet.payload);
     } else {
-        // not a prioritary message : push item to the end of the queue
+        //if the packet should be forwarded, this should be handled with high priority
         push(std::move(item));
     }
 }

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -61,44 +61,24 @@ void handle(Item&& item, const PacketType&) {
         std::same_as<PacketType, packets::DataFragment>       ? DATA_FRAGMENT_LEVEL :
                                                                0;
 
-<<<<<<< HEAD
-void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info,
-                               const uint8_t *data, int data_len) {
-  // convert raw data pointer into buffer (vector) for deserialization TODO
-  // avoid this
-  std::vector<uint8_t> buffer(data, data + data_len);
-=======
     push(std::move(item), level);
 }
 void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
     // convert raw data pointer into buffer (vector) for deserialization TODO avoid this
     std::vector<uint8_t> buffer(data, data + data_len);
->>>>>>> 2026/N1/messages_priorities
 
-  // deserialize
-  auto packet = packets::deserialize(buffer);
+    // deserialize
+    auto packet = packets::deserialize(buffer);
 
-  // if deserialization failed, ignore
-  // could happen because of interference with connecting to a router
-  if (!packet) {
-    ESP_LOGV(TAG, "Failed to deserialize packet!");
-    return;
-  }
+    // if deserialization failed, ignore
+    // could happen because of interference with connecting to a router
+    if (!packet) {
+        ESP_LOGV(TAG, "Failed to deserialize packet!");
+        return;
+    }
 
-<<<<<<< HEAD
-  // update last seen
-  update_last_seen(util::MacAddr(esp_now_info->src_addr));
-
-  // create item
-  Item item{
-      util::MacAddr(esp_now_info->src_addr),
-      esp_now_info->rx_ctrl->rssi,
-      std::move(*packet),
-  };
-
-  // push item to queue
-  push(std::move(item));
-=======
+    // update last seen
+    update_last_seen(util::MacAddr(esp_now_info->src_addr));
     // create item
     Item item{
         util::MacAddr(esp_now_info->src_addr),
@@ -111,7 +91,6 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
         //if the packet should be forwarded, this should be handled with high priority
         push(std::move(item));
     }
->>>>>>> 2026/N1/messages_priorities
 }
 
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -39,6 +39,8 @@ constexpr meshnow::receive::p_level SEARCH_PROBE_LEVEL = CONFIG_SEARCH_PROBE_MES
 constexpr meshnow::receive::p_level SEARCH_REPLY_LEVEL = CONFIG_SEARCH_REPLY_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_REQUEST_LEVEL = CONFIG_CONNECT_REQUEST_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_OK_LEVEL = CONFIG_CONNECT_OK_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CONNECT_OK_ACK_LEVEL = CONFIG_CONNECT_OK_ACK_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CONNECT_END_LEVEL = CONFIG_CONNECT_END_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROUTING_TABLE_ADD_LEVEL = CONFIG_ROUTING_TABLE_ADD_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROUTING_TABLE_REMOVE_LEVEL = CONFIG_ROUTING_TABLE_REMOVE_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROOT_UNREACHABLE_LEVEL = CONFIG_ROOT_UNREACHABLE_MESSAGE_LEVEL;
@@ -66,8 +68,16 @@ void handle(Item&& item, const PacketType&) {
             return CONNECT_REQUEST_LEVEL;
         }
         else if constexpr (std::same_as<PacketType, packets::ConnectOk>) {
-            ESP_LOGD(TAG, "Receiving CONNECTOK : pushing at level %d", CONNECT_OK_LEVEL);
+            ESP_LOGD(TAG, "Receiving CONNECT_OK : pushing at level %d", CONNECT_OK_LEVEL);
             return CONNECT_OK_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::ConnectOkAck) {
+            ESP_LOGD(TAG, "Receiving CONNECT_OK_ACK : pushing at level %d", CONNECT_OK_ACK_LEVEL);
+            return CONNECT_OK_ACK_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::ConnectEnd) {
+            ESP_LOGD(TAG, "Receiving CONNECT_ENT : pushing at level %d", CONNECT_END_LEVEL);
+            return CONNECT_END_LEVEL;
         }
         else if constexpr (std::same_as<PacketType, packets::RoutingTableAdd>) {
             ESP_LOGD(TAG, "Receiving ROUTING_ADD_TABLE : pushing at level %d", ROUTING_TABLE_ADD_LEVEL);

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -14,7 +14,7 @@ namespace meshnow::receive {
 namespace {
 constexpr auto TAG = CREATE_TAG("Receiver");
 constexpr meshnow::receive::p_level STATUS_LEVEL = CONFIG_STATUS_MESSAGE_LEVEL;
-constexpr meshnow::receive::p_level SEARCH_PROVE_LEVEL = CONFIG_SEARCH_PROBE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level SEARCH_PROBE_LEVEL = CONFIG_SEARCH_PROBE_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level SEARCH_REPLY_LEVEL = CONFIG_SEARCH_REPLY_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_REQUEST_LEVEL = CONFIG_CONNECT_REQUEST_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_OK_LEVEL = CONFIG_CONNECT_OK_MESSAGE_LEVEL;
@@ -27,19 +27,53 @@ constexpr meshnow::receive::p_level CUSTOM_DATA_LEVEL = CONFIG_CUSTOM_DATA_MESSA
 }
 template<typename PacketType>
 void handle(Item&& item, const PacketType&) {
-    constexpr p_level level =
-        std::same_as<PacketType, packets::Status>             ? STATUS_LEVEL :
-        std::same_as<PacketType, packets::SearchProbe>        ? SEARCH_PROVE_LEVEL :
-        std::same_as<PacketType, packets::SearchReply>        ? SEARCH_REPLY_LEVEL :
-        std::same_as<PacketType, packets::ConnectRequest>     ? CONNECT_REQUEST_LEVEL :
-        std::same_as<PacketType, packets::ConnectOk>          ? CONNECT_OK_LEVEL :
-        std::same_as<PacketType, packets::RoutingTableAdd>    ? ROUTING_TABLE_ADD_LEVEL :
-        std::same_as<PacketType, packets::RoutingTableRemove> ? ROUTING_TABLE_REMOVE_LEVEL :
-        std::same_as<PacketType, packets::RootUnreachable>    ? ROOT_UNREACHABLE_LEVEL :
-        std::same_as<PacketType, packets::RootReachable>      ? ROOT_REACHABLE_LEVEL :
-        std::same_as<PacketType, packets::DataFragment>       ? DATA_FRAGMENT_LEVEL :
-                                                               0;
-
+    p_level level = [] {
+        if constexpr (std::same_as<PacketType, packets::Status>) {
+            ESP_LOGD(TAG, "Receiving STATUS : pushing at level %d", STATUS_LEVEL);
+            return STATUS_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::SearchProbe>) {
+            ESP_LOGD(TAG, "Receiving SEARCH_PROBE : pushing at level %d", SEARCH_PROBE_LEVEL);
+            return SEARCH_PROBE_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::SearchReply>) {
+            ESP_LOGD(TAG, "Receiving SEARCH_REPLY : pushing at level %d", SEARCH_REPLY_LEVEL);
+            return SEARCH_REPLY_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::ConnectRequest>) {
+            ESP_LOGD(TAG, "Receiving CONNECT_REQUEST : pushing at level %d", CONNECT_REQUEST_LEVEL);
+            return CONNECT_REQUEST_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::ConnectOk>) {
+            ESP_LOGD(TAG, "Receiving CONNECTOK : pushing at level %d", CONNECT_OK_LEVEL);
+            return CONNECT_OK_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::RoutingTableAdd>) {
+            ESP_LOGD(TAG, "Receiving ROUTING_ADD_TABLE : pushing at level %d", ROUTING_TABLE_ADD_LEVEL);
+            return ROUTING_TABLE_ADD_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::RoutingTableRemove>) {
+            ESP_LOGD(TAG, "Receiving ROUTING_REM_TABLE : pushing at level %d", ROUTING_TABLE_REMOVE_LEVEL);
+            return ROUTING_TABLE_REMOVE_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::RootUnreachable>) {
+            ESP_LOGD(TAG, "Receiving ROOT_UNREACHABLE : pushing at level %d", ROOT_UNREACHABLE_LEVEL);
+            return ROOT_UNREACHABLE_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::RootReachable>) {
+            ESP_LOGD(TAG, "Receiving ROOT_REACHABLE : pushing at level %d", ROOT_REACHABLE_LEVEL);
+            return ROOT_REACHABLE_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::DataFragment>) {
+            ESP_LOGD(TAG, "Receiving DATAFRAGM : pushing at level %d", DATA_FRAGMENT_LEVEL);
+            return DATA_FRAGMENT_LEVEL;
+        }
+        else {
+            ESP_LOGD(TAG, "Receiving UNKNOW : pushing at level 0\n");
+            return 0;
+        }
+    }();
+    ESP_LOGD(TAG, "Pushing message to level %d", level);
     push(std::move(item), level);
 }
 void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
@@ -63,7 +97,7 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
         std::move(*packet),
     };
     if (item.packet.to == state::getThisMac() || (item.packet.to == util::MacAddr::root() && state::isRoot())) {
-        handle(std::move(item), item.packet.payload);
+        std::visit([&](const auto& payload) { handle(std::move(item), payload); }, item.packet.payload);    
     } else {
         //if the packet should be forwarded, this should be handled with high priority
         push(std::move(item));


### PR DESCRIPTION
This PR includes the following features (they are merged in one because some features need to me modified when some other are included and otherwise it is a mess) :

- Introduce a ConnectEnd message for false timeouts
- Introduce a ConnectOkAck message that the child sends to the parent to confirm the beginning of a connection
- Modify Status packets so that they contain a seq number, which allows to compute RTTS
- Modifiy the logic of the sending of Status packets so that when received, they are being replied, and a reply allows to compute a specific RTTs for each neighbor node.
- Timeouts are based on RTTs according to RFC 2988.
- Introduce a configurable priority queue at the receiver, so that important messages are treated before less important ones. 