### PR TITLE
2026/n1/merged test

### DIFF
--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -102,67 +102,67 @@ menu "MeshNOW Customization"
     
     config STATUS_MESSAGE_LEVEL
         int "status message level"
-        default 1
+        default 0
         help 
             Priority level of status messages.
         
     config SEARCH_PROBE_MESSAGE_LEVEL
         int "search probe message level"
-        default 1
+        default 0
         help 
             Priority level of search probe messages.
 
     config SEARCH_REPLY_MESSAGE_LEVEL
         int "search reply message level"
-        default 1
+        default 0
         help 
             Priority level of search reply messages.
 
     config CONNECT_REQUEST_MESSAGE_LEVEL
         int "connect request message level"
-        default 1
+        default 0
         help 
             Priority level of connecty request messages.
 
     config CONNECT_OK_MESSAGE_LEVEL
-    int "connect ok message level"
-    default 1
-    help
-        Priority level of connect ok messages.
+        int "connect ok message level"
+        default 0
+        help
+            Priority level of connect ok messages.
 
     config ROUTING_TABLE_ADD_MESSAGE_LEVEL
         int "routing table add message level"
-        default 1
+        default 0
         help
             Priority level of routing table add messages.
 
     config ROUTING_TABLE_REMOVE_MESSAGE_LEVEL
         int "routing table remove message level"
-        default 1
+        default 0
         help
             Priority level of routing table remove messages.
 
     config ROOT_UNREACHABLE_MESSAGE_LEVEL
         int "root unreachable message level"
-        default 1
+        default 0
         help
             Priority level of root unreachable messages.
 
     config ROOT_REACHABLE_MESSAGE_LEVEL
         int "root reachable message level"
-        default 1
+        default 0
         help
             Priority level of root reachable messages.
 
     config DATA_FRAGMENT_MESSAGE_LEVEL
         int "data fragment message level"
-        default 1
+        default 0
         help
             Priority level of data fragment messages.
 
     config CUSTOM_DATA_MESSAGE_LEVEL
         int "custom data message level"
-        default 1
+        default 0
         help
             Priority level of custom data messages.
 

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -83,4 +83,87 @@ menu "MeshNOW Customization"
         help
             The IP address of the DNS server that is used for DNS lookups. This value is encoded as a 4-byte hex value.
 
+    config RECEIVER_PRIORITY_QUEUE_LEVELS
+        int "receiver priority queue levels number"
+        default 1
+        help
+            Specify the number of priority levels used in the receiver. If set to 1, then all messages will have the same priority level.
+            Othewise, the level of priority of different types of messages can help processing important messages sooner than less important
+            ones. The priority level of each kind of message can also be set. 
+    
+    config MESSAGES_PER_PRIORITY_LEVEL
+        int "messages per priority level"
+        default 2
+        help
+            This parameter specify the maximum number of messages with priority level i that will processed one after the other until some 
+            message with lower priority is also processed. If MESSAGES_PER_PRIORITY_LEVEL = n, then, for a priority level i, this number 
+            will be (RECEIVER_PRIORITY_QUEUE_LEVELS - i)*n. Hence, the higher the level of priority, the lower this number. This allows 
+            to make less important messages be processed even if the higher levels are used, and thus ensures some fairness.
+    
+    config STATUS_MESSAGE_LEVEL
+        int "status message level"
+        default 1
+        help 
+            Priority level of status messages.
+        
+    config SEARCH_PROBE_MESSAGE_LEVEL
+        int "search probe message level"
+        default 1
+        help 
+            Priority level of search probe messages.
+
+    config SEARCH_REPLY_MESSAGE_LEVEL
+        int "search reply message level"
+        default 1
+        help 
+            Priority level of search reply messages.
+
+    config CONNECT_REQUEST_MESSAGE_LEVEL
+        int "connect request message level"
+        default 1
+        help 
+            Priority level of connecty request messages.
+
+    config CONNECT_OK_MESSAGE_LEVEL
+    int "connect ok message level"
+    default 1
+    help
+        Priority level of connect ok messages.
+
+    config ROUTING_TABLE_ADD_MESSAGE_LEVEL
+        int "routing table add message level"
+        default 1
+        help
+            Priority level of routing table add messages.
+
+    config ROUTING_TABLE_REMOVE_MESSAGE_LEVEL
+        int "routing table remove message level"
+        default 1
+        help
+            Priority level of routing table remove messages.
+
+    config ROOT_UNREACHABLE_MESSAGE_LEVEL
+        int "root unreachable message level"
+        default 1
+        help
+            Priority level of root unreachable messages.
+
+    config ROOT_REACHABLE_MESSAGE_LEVEL
+        int "root reachable message level"
+        default 1
+        help
+            Priority level of root reachable messages.
+
+    config DATA_FRAGMENT_MESSAGE_LEVEL
+        int "data fragment message level"
+        default 1
+        help
+            Priority level of data fragment messages.
+
+    config CUSTOM_DATA_MESSAGE_LEVEL
+        int "custom data message level"
+        default 1
+        help
+            Priority level of custom data messages.
+
 endmenu

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -46,6 +46,26 @@ menu "MeshNOW Customization"
             During the search phase, the node keeps track of only a few parents at a time to save memory and speed up the connection process.
             This value determines the maximum number of parents that the node keeps track of. If a better parent is found, the node will replace the worst parent it is tracking.
 
+    config USE_CONNECT_OK_ACK_MESSAGE
+        int "Use connect ok ack message to validate the reception of a connect ok message"
+        default 1
+        help 
+            Use connect ok ack message to validate the reception of a connect ok message. The parent registers the child only when it receives an connect ok ack message.
+            When it receives a connect request, it sends back a connect ok, to which the child respond with a connect ok ack
+    
+    config USE_CONNECT_END_MESSAGE
+        int "Use connect end message"
+        default 1
+        help
+            Sending an end of connection message to tear down a connection rather than waiting for the neighbor to time out.
+
+    config USE_RTT_FOR_TIMEOUT
+        int "Use round-trip-time (RTT) to compute timeout"
+        default 1
+        help
+            Instead of having a hard-threshold time out, use an estimate of the time it takes for two neighbors to communicate. Samples of RTT are computed by changing the behavior of status packets, 
+            so that they can be responded to, and the first and second moments are estimated by using a leaky integrator. The timeout is then specific to each neighbor, and a function of the first 
+            and second moments of the RTT.
     config CONNECT_TIMEOUT
         int "Connection timeout (ms)"
         default 3000

--- a/meshnow/Kconfig.projbuild
+++ b/meshnow/Kconfig.projbuild
@@ -137,6 +137,18 @@ menu "MeshNOW Customization"
         help
             Priority level of connect ok messages.
 
+    config CONNECT_OK_ACK_MESSAGE_LEVEL
+        int "connect ok ack message level"
+        default 0
+        help
+            Priority level of connect ok ack messages.
+    
+    config CONNECT_END_MESSAGE_LEVEL
+        int "connect end message level"
+        default 0
+        help
+            Priority level of connect end messages.
+
     config ROUTING_TABLE_ADD_MESSAGE_LEVEL
         int "routing table add message level"
         default 0

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -294,6 +294,7 @@ void ConnectJob::AwaitingConnectResponsePhase::performAction(ConnectJob &job) {
     ESP_LOGI(TAG, "Connect response timeout fired (%s)",
              origin_ == RequestOrigin::INITIAL ? "connect" : "reconnect");
     event::Internal::fire(event::InternalEvent::TIMEOUT_CONNECT_RESPONSE, nullptr, 0);
+}
 
 void ConnectJob::AwaitingConnectResponsePhase::event_handler(ConnectJob &job, event::InternalEvent event,
                                                              void *event_data) {

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -50,11 +50,15 @@ void StatusSendJob::sendStatus() {
         packets::Status payload{
             .state = state,
             .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
+            #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
+            //odd means seq
             .seq = child.rtt_seq | 1,
+            #endif
         };
+        #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
         child.rtt_seq += 2;
         child.last_seen_rtt = xTaskGetTickCount();
-
+        #endif
         send::enqueuePayload(payload, send::DirectOnce{child.mac});
     }
     if (layout.hasParent()) {
@@ -62,10 +66,15 @@ void StatusSendJob::sendStatus() {
         packets::Status payload{
             .state = state,
             .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
-            .seq = parent.rtt_seq,
+            #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
+            //odd means seq
+            .seq = parent.rtt_seq | 1,
+            #endif
         };
-        parent.rtt_seq += 1;
+        #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
+        parent.rtt_seq += 2;
         parent.last_seen_rtt = xTaskGetTickCount();
+        #endif
 
         send::enqueuePayload(payload, send::DirectOnce{parent.mac});
     }
@@ -166,7 +175,11 @@ void NeighborCheckJob::performAction() {
 
     // direct children
     for (auto it = layout.getChildren().begin(); it != layout.getChildren().end();) {
+        #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
         auto timeout = it->rtt_est + 4*it->rtt_dev_est;
+        #else
+        auto timeout = KEEP_ALIVE_TIMEOUT;
+        #endif
         if (now - it->last_seen > timeout) {
             auto mac = it->mac;
             ESP_LOGW(TAG, "Direct child " MACSTR " timed out (timeout %d)", MAC2STR(mac), timeout);
@@ -178,8 +191,9 @@ void NeighborCheckJob::performAction() {
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
                                &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
             }
-
+            #ifdef CONFIG_USE_CONNECT_END_MESSAGE
             send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(mac));
+            #endif
 
             layout.removeChild(it->mac);
             // send event upstream
@@ -192,7 +206,11 @@ void NeighborCheckJob::performAction() {
     // parent
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
+        #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
         auto timeout = parent.rtt_est + 4*parent.rtt_dev_est;
+        #else 
+        auto timeout = KEEP_ALIVE_TIMEOUT;
+        #endif
         if (now - parent.last_seen > timeout) {
             ESP_LOGW(TAG, "Parent " MACSTR " timed out (timeout)", MAC2STR(parent.mac), timeout);
 
@@ -204,9 +222,10 @@ void NeighborCheckJob::performAction() {
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
-
+            #ifdef CONFIG_USE_CONNECT_END_MESSAGE
             // Send the ConnectEnd packet
             send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(parent.mac));
+            #endif
 
             layout.removeParent();
             state::setState(state::State::DISCONNECTED_FROM_PARENT);

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -73,22 +73,22 @@ void UnreachableTimeoutJob::performAction() {
         // if we haven't lost the parent by now because of a Keep Alive timeout, remove it
         auto& layout = layout::Layout::get();
         if (layout.hasParent()) {
+            auto parent_mac = layout.getParent().mac;
+
             // fire disconnect event
             {
                 meshnow_event_parent_disconnected_t parent_disconnected_event;
-                util::MacAddr& parent_mac = layout::Layout::get().getParent().mac;
                 std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_disconnected_event.parent_mac);
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
-            
+
             // Send the ConnectEnd packet
-            auto payload = packets::ConnectEnd{};
-            send::enqueuePayload(payload, send::DirectOnce{parent.mac});
+            send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(parent_mac));
+
             layout.removeParent();
-            state::setState(state::State::DISCONNECTED_FROM_PARENT);  // set state to disconnected
+            state::setState(state::State::DISCONNECTED_FROM_PARENT);
         }
-}
     }
 }
 
@@ -162,6 +162,8 @@ void NeighborCheckJob::performAction() {
                                &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
             }
 
+            send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(mac));
+
             layout.removeChild(it->mac);
             // send event upstream
             sendChildDisconnected(mac);
@@ -186,8 +188,8 @@ void NeighborCheckJob::performAction() {
             }
 
             // Send the ConnectEnd packet
-            auto payload = packets::ConnectEnd{};
-            send::enqueuePayload(payload, send::DirectOnce{parent.mac});
+            send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(parent.mac));
+
             layout.removeParent();
             state::setState(state::State::DISCONNECTED_FROM_PARENT);
         }

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -182,7 +182,7 @@ void NeighborCheckJob::performAction() {
         #endif
         if (now - it->last_seen > timeout) {
             auto mac = it->mac;
-            ESP_LOGW(TAG, "Direct child " MACSTR " timed out (timeout %d)", MAC2STR(mac), timeout);
+            ESP_LOGW(TAG, "Direct child " MACSTR " timed out (timeout %lu)", MAC2STR(mac), timeout);
 
             // fire disconnect event
             {
@@ -212,7 +212,7 @@ void NeighborCheckJob::performAction() {
         auto timeout = KEEP_ALIVE_TIMEOUT;
         #endif
         if (now - parent.last_seen > timeout) {
-            ESP_LOGW(TAG, "Parent " MACSTR " timed out (timeout)", MAC2STR(parent.mac), timeout);
+            ESP_LOGW(TAG, "Parent " MACSTR " timed out (timeout %lu)", MAC2STR(parent.mac), timeout);
 
             // fire disconnect event
             {

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -169,7 +169,7 @@ void NeighborCheckJob::performAction() {
         auto timeout = it->rtt_est + 4*it->rtt_dev_est;
         if (now - it->last_seen > timeout) {
             auto mac = it->mac;
-            ESP_LOGW(TAG, "Direct child " MACSTR " timed out", MAC2STR(mac));
+            ESP_LOGW(TAG, "Direct child " MACSTR " timed out (timeout %d)", MAC2STR(mac), timeout);
 
             // fire disconnect event
             {
@@ -194,7 +194,7 @@ void NeighborCheckJob::performAction() {
         auto& parent = layout.getParent();
         auto timeout = parent.rtt_est + 4*parent.rtt_dev_est;
         if (now - parent.last_seen > timeout) {
-            ESP_LOGW(TAG, "Parent " MACSTR " timed out", MAC2STR(parent.mac));
+            ESP_LOGW(TAG, "Parent " MACSTR " timed out (timeout)", MAC2STR(parent.mac), timeout);
 
             // fire disconnect event
             {

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -45,8 +45,8 @@ void StatusSendJob::performAction() {
 void StatusSendJob::sendStatus() {
     ESP_LOGD(TAG, "Sending status beacons to neighbors");
     auto state = state::getState();
-    auto layout = layout::Layout::get();
-    for (const auto& child : layout.getChildren()){
+    auto& layout = layout::Layout::get();
+    for (auto& child : layout.getChildren()){
         packets::Status payload{
             .state = state,
             .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
@@ -186,7 +186,7 @@ void NeighborCheckJob::performAction() {
     // parent
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
-        auto timeout = it->rtt_est + 4*it->rtt_dev_est;
+        auto timeout = parent.rtt_est + 4*parent.rtt_dev_est;
         if (now - parent.last_seen > timeout) {
             ESP_LOGW(TAG, "Parent " MACSTR " timed out", MAC2STR(parent.mac));
 

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -45,15 +45,31 @@ void StatusSendJob::performAction() {
 void StatusSendJob::sendStatus() {
     ESP_LOGD(TAG, "Sending status beacons to neighbors");
     auto state = state::getState();
+    auto layout = layout::Layout::get();
+    for (const auto& child : layout.getChildren()){
+        packets::Status payload{
+            .state = state,
+            .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
+            .seq = child.rtt_seq | 1,
+        };
+        child.rtt_seq += 2;
+        child.last_seen_rtt = xTaskGetTickCount();
 
-    packets::Status payload{
-        .state = state,
-        .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
-    };
+        send::enqueuePayload(payload, send::DirectOnce{child.mac});
+    }
+    if (layout.hasParent()) {
+        auto& parent = layout.getParent();
+        packets::Status payload{
+            .state = state,
+            .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
+            .seq = parent.rtt_seq,
+        };
+        parent.rtt_seq += 1;
+        parent.last_seen_rtt = xTaskGetTickCount();
 
-    send::enqueuePayload(payload, send::NeighborsOnce{});
+        send::enqueuePayload(payload, send::DirectOnce{parent.mac});
+    }
 }
-
 // UnreachableTimeoutJob //
 
 TickType_t UnreachableTimeoutJob::nextActionAt() const noexcept {
@@ -146,7 +162,8 @@ void NeighborCheckJob::performAction() {
 
     // direct children
     for (auto it = layout.getChildren().begin(); it != layout.getChildren().end();) {
-        if (now - it->last_seen > KEEP_ALIVE_TIMEOUT) {
+        auto timeout = it->rtt_est + 4*it->rtt_dev_est;
+        if (now - it->last_seen > timeout) {
             auto mac = it->mac;
             ESP_LOGW(TAG, "Direct child " MACSTR " timed out", MAC2STR(mac));
 
@@ -169,7 +186,8 @@ void NeighborCheckJob::performAction() {
     // parent
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
-        if (now - parent.last_seen > KEEP_ALIVE_TIMEOUT) {
+        auto timeout = it->rtt_est + 4*it->rtt_dev_est;
+        if (now - parent.last_seen > timeout) {
             ESP_LOGW(TAG, "Parent " MACSTR " timed out", MAC2STR(parent.mac));
 
             // fire disconnect event

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -81,10 +81,14 @@ void UnreachableTimeoutJob::performAction() {
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
-
+            
+            // Send the ConnectEnd packet
+            auto payload = packets::ConnectEnd{};
+            send::enqueuePayload(payload, send::DirectOnce{parent.mac});
             layout.removeParent();
             state::setState(state::State::DISCONNECTED_FROM_PARENT);  // set state to disconnected
         }
+}
     }
 }
 
@@ -181,6 +185,9 @@ void NeighborCheckJob::performAction() {
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
 
+            // Send the ConnectEnd packet
+            auto payload = packets::ConnectEnd{};
+            send::enqueuePayload(payload, send::DirectOnce{parent.mac});
             layout.removeParent();
             state::setState(state::State::DISCONNECTED_FROM_PARENT);
         }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -277,6 +277,41 @@ void PacketHandler::handle(const MetaData& meta, const packets::RootReachable& p
     send::enqueuePayload(packets::RootUnreachable{}, send::DownstreamRetry{});
 }
 
+void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
+    if (!lastHopIsFrom(meta)) return;
+
+    auto& layout = layout::Layout::get();
+
+    if (isParent(meta.last_hop)) {
+        ESP_LOGI(TAG, "Parent " MACSTR " ended connection", MAC2STR(meta.last_hop));
+
+        {
+            meshnow_event_parent_disconnected_t parent_disconnected_event;
+            util::MacAddr& parent_mac = layout.getParent().mac;
+            std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_disconnected_event.parent_mac);
+            esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
+                           &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
+        }
+
+        layout.removeParent();
+        state::setState(state::State::DISCONNECTED_FROM_PARENT);
+        return;
+    }
+
+    if (isChild(meta.last_hop)) {
+        ESP_LOGI(TAG, "Child " MACSTR " ended connection", MAC2STR(meta.last_hop));
+
+        {
+            meshnow_event_child_disconnected_t child_disconnected_event;
+            std::copy(meta.last_hop.addr.begin(), meta.last_hop.addr.end(), child_disconnected_event.child_mac);
+            esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
+                           &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
+        }
+
+        layout.removeChild(meta.last_hop);
+    }
+}
+
 void PacketHandler::handle(const MetaData& meta, const packets::DataFragment& p) {
     if (!isNeighbor(meta.last_hop)) return;
 

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -242,7 +242,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectRequest& 
     // send reply
     ESP_LOGV(TAG, "Sending Connect Response");
     send::enqueuePayload(packets::ConnectOk{state::getRootMac()}, send::DirectOnce(meta.from));
-    #ifdef !CONFIG_USE_CONNECT_OK_ACK_MESSAGE
+    #ifndef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
         add_child(meta);
     #endif
 }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -190,25 +190,9 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectRequest& 
     if (knowsNode(meta.from)) return;
     if (!canAcceptNewChild()) return;
 
-    // add to layout
-    layout().addChild(meta.from);
-
-    ESP_LOGI(TAG, "Child " MACSTR " connected", MAC2STR(meta.from));
-
-    // fire connect event
-    {
-        meshnow_event_child_connected_t child_connected_event;
-        std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_connected_event.child_mac);
-        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_CONNECTED, &child_connected_event,
-                       sizeof(child_connected_event), portMAX_DELAY);
-    }
-
     // send reply
     ESP_LOGV(TAG, "Sending Connect Response");
     send::enqueuePayload(packets::ConnectOk{state::getRootMac()}, send::DirectOnce(meta.from));
-
-    // send routing table add packet upstream
-    send::enqueuePayload(packets::RoutingTableAdd{meta.from}, send::UpstreamRetry{});
 }
 
 void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
@@ -223,7 +207,34 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
         .rssi = meta.rssi
     };
     event::Internal::fire(event::InternalEvent::GOT_CONNECT_RESPONSE, &data, sizeof(data));
+
+    //sends a response
+    send::enqueuePayload(packets::ConnectOkAck{}, send::DirectOnce{meta.from});
 }
+
+void PacketHandler::handle(const MetaData& meta, const packets::ConnectOkAck& p) {
+    if (!lastHopIsFrom(meta)) return;
+    if (knowsNode(meta.from)) return;
+    if (!reachesRoot() || !canAcceptNewChild()) {
+        //send ConnectEnd message
+    }
+    // add to layout
+    layout().addChild(meta.from);
+
+    ESP_LOGI(TAG, "Child " MACSTR " connected", MAC2STR(meta.from));
+
+    // fire connect event
+    {
+        meshnow_event_child_connected_t child_connected_event;
+        std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_connected_event.child_mac);
+        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_CONNECTED, &child_connected_event,
+                       sizeof(child_connected_event), portMAX_DELAY);
+    }
+
+    // send routing table add packet upstream
+    send::enqueuePayload(packets::RoutingTableAdd{meta.from}, send::UpstreamRetry{});
+}
+
 
 void PacketHandler::handle(const MetaData& meta, const packets::RoutingTableAdd& p) {
     // TODO safety checks

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -178,6 +178,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
         auto rtt_dev_sample = neigh->rtt_est >= rtt_sample ? (neigh->rtt_est - rtt_sample) : (rtt_sample - neigh->rtt_est);
         neigh->rtt_est = ((neigh->rtt_est * 7) + rtt_sample)/8;
         neigh->rtt_dev_est = ((neigh->rtt_dev_est * 3) + rtt_dev_sample)/4;
+        ESP_LOGV(TAG, "new rtt sample %d, rtt estimate %d and rtt dev estimate %dcode ", rtt_sample, neigh->rtt_est, neigh->rtt_dev_est);
     }
     return;
 }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -282,7 +282,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
 
     auto& layout = layout::Layout::get();
 
-    if (isParent(meta.last_hop)) {
+    if (isParent(meta.from)) {
         ESP_LOGI(TAG, "Parent " MACSTR " ended connection", MAC2STR(meta.last_hop));
 
         {
@@ -298,17 +298,17 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
         return;
     }
 
-    if (isChild(meta.last_hop)) {
-        ESP_LOGI(TAG, "Child " MACSTR " ended connection", MAC2STR(meta.last_hop));
+    if (isChild(meta.from)) {
+        ESP_LOGI(TAG, "Child " MACSTR " ended connection", MAC2STR(meta.from));
 
         {
             meshnow_event_child_disconnected_t child_disconnected_event;
-            std::copy(meta.last_hop.addr.begin(), meta.last_hop.addr.end(), child_disconnected_event.child_mac);
+            std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_disconnected_event.child_mac);
             esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
                            &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
         }
 
-        layout.removeChild(meta.last_hop);
+        layout.removeChild(meta.from);
     }
 }
 

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -125,6 +125,24 @@ inline bool disconnected() {
     }
 }
 
+inline void add_child(const MetaData& meta) {
+    // add to layout
+    layout().addChild(meta.from);
+
+    ESP_LOGI(TAG, "Child " MACSTR " connected", MAC2STR(meta.from));
+
+    // fire connect event
+    {
+        meshnow_event_child_connected_t child_connected_event;
+        std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_connected_event.child_mac);
+        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_CONNECTED, &child_connected_event,
+                       sizeof(child_connected_event), portMAX_DELAY);
+    }
+
+    // send routing table add packet upstream
+    send::enqueuePayload(packets::RoutingTableAdd{meta.from}, send::UpstreamRetry{});
+}
+
 }  // namespace
 
 // HANDLERS //
@@ -158,6 +176,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
             }
         }
     }
+    #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
     auto* neigh = layout.hasChild(meta.from) ? &layout.getChild(meta.from) : 
                     layout.hasParent() && layout.getParent().mac == meta.from ? &layout.getParent() :
                     nullptr;
@@ -165,6 +184,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
     if (neigh == nullptr) return;
 
     if ((p.seq&1) == 1) {
+        //odd means seq, must reply with an ack
         auto state = state::getState();
         packets::Status response{
             .state = state,
@@ -173,14 +193,20 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
         };
         send::enqueuePayload(response, send::DirectOnce{meta.from});
     } else {
+        //even means ack, must check the sequence match and compute new rtt est
         if (neigh->rtt_seq != p.seq) return;
         auto rtt_sample = xTaskGetTickCount() - neigh->last_seen_rtt;
         auto rtt_dev_sample = neigh->rtt_est >= rtt_sample ? (neigh->rtt_est - rtt_sample) : (rtt_sample - neigh->rtt_est);
         neigh->rtt_est = ((neigh->rtt_est * 7) + rtt_sample)/8;
+        //sometimes we have little precision problem with for instance rtt_est = 0 and rtt_sample = 1
+        neigh->rtt_est = neigh->rtt_est == 0 ? 1 : neigh->rtt_est;
+        //same precaution here
         neigh->rtt_dev_est = ((neigh->rtt_dev_est * 3) + rtt_dev_sample)/4;
+        neigh->rtt_dev_est = neigh->rtt_dev_est == 0 ? 1 : neigh->rtt_est;
         ESP_LOGV(TAG, "new rtt sample %d, rtt estimate %d and rtt dev estimate %dcode ", rtt_sample, neigh->rtt_est, neigh->rtt_dev_est);
     }
     return;
+    #endif
 }
 
 void PacketHandler::handle(const MetaData& meta, const packets::SearchProbe& p) {
@@ -216,6 +242,9 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectRequest& 
     // send reply
     ESP_LOGV(TAG, "Sending Connect Response");
     send::enqueuePayload(packets::ConnectOk{state::getRootMac()}, send::DirectOnce(meta.from));
+    #ifdef !CONFIG_USE_CONNECT_OK_ACK_MESSAGE
+        add_child(meta);
+    #endif
 }
 
 void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
@@ -231,10 +260,13 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOk& p) {
     };
     event::Internal::fire(event::InternalEvent::GOT_CONNECT_RESPONSE, &data, sizeof(data));
 
+    #ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
     //sends a response
     send::enqueuePayload(packets::ConnectOkAck{}, send::DirectOnce{meta.from});
+    #endif
 }
 
+#ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
 void PacketHandler::handle(const MetaData& meta, const packets::ConnectOkAck& p) {
     if (!lastHopIsFrom(meta)) return;
     if (knowsNode(meta.from)) return;
@@ -243,23 +275,9 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOkAck& p)
         ESP_LOGI(TAG, "Received connect acknowledge but cannot accept it anymore : send connect end");
         return;
     }
-    // add to layout
-    layout().addChild(meta.from);
-
-    ESP_LOGI(TAG, "Child " MACSTR " connected", MAC2STR(meta.from));
-
-    // fire connect event
-    {
-        meshnow_event_child_connected_t child_connected_event;
-        std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_connected_event.child_mac);
-        esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_CONNECTED, &child_connected_event,
-                       sizeof(child_connected_event), portMAX_DELAY);
-    }
-
-    // send routing table add packet upstream
-    send::enqueuePayload(packets::RoutingTableAdd{meta.from}, send::UpstreamRetry{});
+    add_child(meta);
 }
-
+#endif
 
 void PacketHandler::handle(const MetaData& meta, const packets::RoutingTableAdd& p) {
     // TODO safety checks
@@ -312,7 +330,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::RootReachable& p
     // forward to all children
     send::enqueuePayload(packets::RootUnreachable{}, send::DownstreamRetry{});
 }
-
+#ifdef CONFIG_USE_CONNECT_END_MESSAGE
 void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
     if (!lastHopIsFrom(meta)) return;
 
@@ -347,6 +365,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
         layout.removeChild(meta.from);
     }
 }
+#endif
 
 void PacketHandler::handle(const MetaData& meta, const packets::DataFragment& p) {
     if (!isNeighbor(meta.last_hop)) return;

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -137,27 +137,49 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
     // is parent?
     if (layout.hasParent()) {
         auto& parent = layout.getParent();
-        if (parent.mac != meta.from) return;
+        if (parent.mac == meta.from) {
 
-        switch (p.state) {
-            case state::State::DISCONNECTED_FROM_PARENT:
-            case state::State::CONNECTED_TO_PARENT: {
-                state::setState(state::State::CONNECTED_TO_PARENT);
-                break;
-            }
-            case state::State::REACHES_ROOT: {
-                // this should never be the case, but we never know with malicious packets
-                if (!p.root.has_value()) return;
+            switch (p.state) {
+                case state::State::DISCONNECTED_FROM_PARENT:
+                case state::State::CONNECTED_TO_PARENT: {
+                    state::setState(state::State::CONNECTED_TO_PARENT);
+                    break;
+                }
+                case state::State::REACHES_ROOT: {
+                    // this should never be the case, but we never know with malicious packets
+                    if (!p.root.has_value()) break;
 
-                // set root mac
-                state::setRootMac(p.root.value());
-                // set state
-                state::setState(state::State::REACHES_ROOT);
-                break;
+                    // set root mac
+                    state::setRootMac(p.root.value());
+                    // set state
+                    state::setState(state::State::REACHES_ROOT);
+                    break;
+                }
             }
         }
-        return;
     }
+
+    layout::Neighbor neigh;
+    if (layout.hasChild(meta.from)) {
+        neigh = layout.getChild(meta.from);
+    } else if (layout.hasParent()) {
+        neigh = layout.getParent();
+    }
+    if (p.seq&1 == 1) {
+        packets::Status response{
+            .state = state::getState(),
+            .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
+            .seq = (p.seq ^ 1) + 2,
+        }
+        send::enqueuePayload(response, send::DirectOnce{meta.from});
+    } else {
+        if (neigh.rtt_seq != p.seq) return;
+        auto rtt_sample = xTaskGetTickCount() - neigh.last_seen_rtt;
+        auto rtt_dev_sample = neigh.rtt_est >= rtt_sample ? (neigh.rtt_est - rtt_sample) : (rtt_sample - neigh.rtt_est)
+        neigh.rtt_est = ((neigh.rtt_est * 7) + rtt_sample)/8
+        neigh.rtt_dev_est = ((neigh.rtt_dev_est * 3) + rtt_dev_sample)/4
+    }
+    return;
 }
 
 void PacketHandler::handle(const MetaData& meta, const packets::SearchProbe& p) {

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -158,26 +158,26 @@ void PacketHandler::handle(const MetaData& meta, const packets::Status& p) {
             }
         }
     }
+    auto* neigh = layout.hasChild(meta.from) ? &layout.getChild(meta.from) : 
+                    layout.hasParent() && layout.getParent().mac == meta.from ? &layout.getParent() :
+                    nullptr;
+                    
+    if (neigh == nullptr) return;
 
-    layout::Neighbor neigh;
-    if (layout.hasChild(meta.from)) {
-        neigh = layout.getChild(meta.from);
-    } else if (layout.hasParent()) {
-        neigh = layout.getParent();
-    }
-    if (p.seq&1 == 1) {
+    if ((p.seq&1) == 1) {
+        auto state = state::getState();
         packets::Status response{
-            .state = state::getState(),
+            .state = state,
             .root = state == state::State::REACHES_ROOT ? std::make_optional(state::getRootMac()) : std::nullopt,
             .seq = (p.seq ^ 1) + 2,
-        }
+        };
         send::enqueuePayload(response, send::DirectOnce{meta.from});
     } else {
-        if (neigh.rtt_seq != p.seq) return;
-        auto rtt_sample = xTaskGetTickCount() - neigh.last_seen_rtt;
-        auto rtt_dev_sample = neigh.rtt_est >= rtt_sample ? (neigh.rtt_est - rtt_sample) : (rtt_sample - neigh.rtt_est)
-        neigh.rtt_est = ((neigh.rtt_est * 7) + rtt_sample)/8
-        neigh.rtt_dev_est = ((neigh.rtt_dev_est * 3) + rtt_dev_sample)/4
+        if (neigh->rtt_seq != p.seq) return;
+        auto rtt_sample = xTaskGetTickCount() - neigh->last_seen_rtt;
+        auto rtt_dev_sample = neigh->rtt_est >= rtt_sample ? (neigh->rtt_est - rtt_sample) : (rtt_sample - neigh->rtt_est);
+        neigh->rtt_est = ((neigh->rtt_est * 7) + rtt_sample)/8;
+        neigh->rtt_dev_est = ((neigh->rtt_dev_est * 3) + rtt_dev_sample)/4;
     }
     return;
 }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -238,7 +238,9 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectOkAck& p)
     if (!lastHopIsFrom(meta)) return;
     if (knowsNode(meta.from)) return;
     if (!reachesRoot() || !canAcceptNewChild()) {
-        //send ConnectEnd message
+        send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce{meta.from});
+        ESP_LOGI(TAG, "Received connect acknowledge but cannot accept it anymore : send connect end");
+        return;
     }
     // add to layout
     layout().addChild(meta.from);

--- a/meshnow/src/job/packet_handler.hpp
+++ b/meshnow/src/job/packet_handler.hpp
@@ -30,12 +30,16 @@ class PacketHandler {
     static void handle(const MetaData& meta, const packets::SearchReply& p);
     static void handle(const MetaData& meta, const packets::ConnectRequest& p);
     static void handle(const MetaData& meta, const packets::ConnectOk& p);
+    #ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
     static void handle(const MetaData& meta, const packets::ConnectOkAck& p);
+    #endif
     static void handle(const MetaData& meta, const packets::RoutingTableAdd& p);
     static void handle(const MetaData& meta, const packets::RoutingTableRemove& p);
     static void handle(const MetaData& meta, const packets::RootUnreachable& p);
     static void handle(const MetaData& meta, const packets::RootReachable& p);
+    #ifdef CONFIG_USE_CONNECT_END_MESSAGE
     static void handle(const MetaData& meta, const packets::ConnectEnd& p);
+    #endif
     static void handle(const MetaData& meta, const packets::DataFragment& p);
     static void handle(const MetaData& meta, const packets::CustomData& p);
 };

--- a/meshnow/src/job/packet_handler.hpp
+++ b/meshnow/src/job/packet_handler.hpp
@@ -30,6 +30,7 @@ class PacketHandler {
     static void handle(const MetaData& meta, const packets::SearchReply& p);
     static void handle(const MetaData& meta, const packets::ConnectRequest& p);
     static void handle(const MetaData& meta, const packets::ConnectOk& p);
+    static void handle(const MetaData& meta, const packets::ConnectOkAck& p);
     static void handle(const MetaData& meta, const packets::RoutingTableAdd& p);
     static void handle(const MetaData& meta, const packets::RoutingTableRemove& p);
     static void handle(const MetaData& meta, const packets::RootUnreachable& p);

--- a/meshnow/src/job/packet_handler.hpp
+++ b/meshnow/src/job/packet_handler.hpp
@@ -34,6 +34,7 @@ class PacketHandler {
     static void handle(const MetaData& meta, const packets::RoutingTableRemove& p);
     static void handle(const MetaData& meta, const packets::RootUnreachable& p);
     static void handle(const MetaData& meta, const packets::RootReachable& p);
+    static void handle(const MetaData& meta, const packets::ConnectEnd& p);
     static void handle(const MetaData& meta, const packets::DataFragment& p);
     static void handle(const MetaData& meta, const packets::CustomData& p);
 };

--- a/meshnow/src/layout.cpp
+++ b/meshnow/src/layout.cpp
@@ -56,7 +56,10 @@ Neighbor& Layout::getParent() { return parent_.value(); }
 
 void Layout::setParent(const util::MacAddr& mac) { parent_.emplace(mac); }
 
-void Layout::removeParent() { parent_.reset(); }
+void Layout::removeParent() { 
+    
+    parent_.reset(); 
+}
 
 bool Layout::hasChild(const util::MacAddr& mac) const {
     for (const auto& child : children_) {

--- a/meshnow/src/layout.hpp
+++ b/meshnow/src/layout.hpp
@@ -26,10 +26,12 @@ struct Node {
 struct Neighbor : Node {
     using Node::Node;
     TickType_t last_seen{xTaskGetTickCount()};
+    #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
     TickType_t last_seen_rtt{0};
     TickType_t rtt_est{pdMS_TO_TICKS(CONFIG_KEEP_ALIVE_TIMEOUT)};
     TickType_t rtt_dev_est{0};
     uint32_t rtt_seq{0};
+    #endif
 };
 
 struct Child : Neighbor {

--- a/meshnow/src/layout.hpp
+++ b/meshnow/src/layout.hpp
@@ -26,6 +26,10 @@ struct Node {
 struct Neighbor : Node {
     using Node::Node;
     TickType_t last_seen{xTaskGetTickCount()};
+    TickType_t last_seen_rtt{0};
+    TickType_t rtt_est{pdMS_TO_TICKS(CONFIG_KEEP_ALIVE_TIMEOUT)};
+    TickType_t rtt_dev_est{0};
+    uint32_t rtt_seq{0};
 };
 
 struct Child : Neighbor {

--- a/meshnow/src/packets.cpp
+++ b/meshnow/src/packets.cpp
@@ -106,6 +106,7 @@ static void serialize(S& s, Status& p) {
     s.value1b(p.state);
     // TODO optimize with custom extension
     s.ext(p.root, bitsery::ext::StdOptional{});
+    s.value4b(p.seq);
 }
 
 template <typename S>

--- a/meshnow/src/packets.cpp
+++ b/meshnow/src/packets.cpp
@@ -129,6 +129,11 @@ static void serialize(S& s, ConnectOk& p) {
 }
 
 template <typename S>
+static void serialize(S&, ConnectOkAck&) {
+    //no data
+}
+
+template <typename S>
 static void serialize(S& s, RoutingTableAdd& p) {
     s.object(p.entry);
 }

--- a/meshnow/src/packets.cpp
+++ b/meshnow/src/packets.cpp
@@ -106,18 +106,21 @@ static void serialize(S& s, Status& p) {
     s.value1b(p.state);
     // TODO optimize with custom extension
     s.ext(p.root, bitsery::ext::StdOptional{});
+    #ifdef CONFIG_USE_RTT_FOR_TIMEOUT
     s.value4b(p.seq);
+    #endif
 }
 
 template <typename S>
 static void serialize(S&, SearchProbe&) {
     // no data
 }
-
+#ifdef CONFIG_USE_CONNECT_END_MESSAGE
 template <typename S>
 static void serialize(S&, ConnectEnd&) {
     // no data
 }
+#endif
 
 
 template <typename S>
@@ -134,11 +137,12 @@ template <typename S>
 static void serialize(S& s, ConnectOk& p) {
     s.object(p.root);
 }
-
+#ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
 template <typename S>
 static void serialize(S&, ConnectOkAck&) {
     //no data
 }
+#endif
 
 template <typename S>
 static void serialize(S& s, RoutingTableAdd& p) {

--- a/meshnow/src/packets.cpp
+++ b/meshnow/src/packets.cpp
@@ -114,6 +114,12 @@ static void serialize(S&, SearchProbe&) {
 }
 
 template <typename S>
+static void serialize(S&, ConnectEnd&) {
+    // no data
+}
+
+
+template <typename S>
 static void serialize(S&, SearchReply&) {
     // no data
 }

--- a/meshnow/src/packets.hpp
+++ b/meshnow/src/packets.hpp
@@ -13,6 +13,7 @@ namespace meshnow::packets {
 struct Status {
     state::State state;
     std::optional<util::MacAddr> root;
+    uint32_t seq;
 };
 
 struct SearchProbe {};

--- a/meshnow/src/packets.hpp
+++ b/meshnow/src/packets.hpp
@@ -56,8 +56,10 @@ struct CustomData {
     util::Buffer data;
 };
 
+struct ConnectEnd {};
+
 using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, RoutingTableAdd,
-                             RoutingTableRemove, RootUnreachable, RootReachable, DataFragment, CustomData>;
+                             RoutingTableRemove, RootUnreachable, RootReachable, DataFragment, CustomData, ConnectEnd>;
 
 struct Packet {
     uint32_t id;

--- a/meshnow/src/packets.hpp
+++ b/meshnow/src/packets.hpp
@@ -25,6 +25,8 @@ struct ConnectOk {
     util::MacAddr root;
 };
 
+struct ConnectOkAck {};
+
 struct RoutingTableAdd {
     util::MacAddr entry;
 };
@@ -56,8 +58,9 @@ struct CustomData {
     util::Buffer data;
 };
 
-using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, RoutingTableAdd,
-                             RoutingTableRemove, RootUnreachable, RootReachable, DataFragment, CustomData>;
+using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, ConnectOkAck, 
+                             RoutingTableAdd, RoutingTableRemove, RootUnreachable, RootReachable, 
+                             DataFragment, CustomData>;
 
 struct Packet {
     uint32_t id;

--- a/meshnow/src/packets.hpp
+++ b/meshnow/src/packets.hpp
@@ -13,7 +13,9 @@ namespace meshnow::packets {
 struct Status {
     state::State state;
     std::optional<util::MacAddr> root;
+#ifdef CONFIG_USE_RTT_FOR_TIMEOUT
     uint32_t seq;
+#endif
 };
 
 struct SearchProbe {};
@@ -26,9 +28,13 @@ struct ConnectOk {
     util::MacAddr root;
 };
 
+#ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
 struct ConnectOkAck {};
+#endif
 
+#ifdef CONFIG_USE_CONNECT_END_MESSAGE
 struct ConnectEnd {};
+#endif
 
 
 struct RoutingTableAdd {
@@ -63,9 +69,16 @@ struct CustomData {
 };
 
 
-using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, ConnectOkAck, 
-                             ConnectEnd, RoutingTableAdd, RoutingTableRemove, RootUnreachable, RootReachable, 
-                             DataFragment, CustomData>;
+using Payload = std::variant<Status, SearchProbe, SearchReply, ConnectRequest, ConnectOk, 
+                            RoutingTableAdd, RoutingTableRemove, RootUnreachable, RootReachable, 
+                            DataFragment,
+                            #ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
+                            ConnectOkAck,
+                            #endif
+                            #ifdef CONFIG_USE_CONNECT_END_MESSAGE
+                            ConnectEnd,
+                            #endif
+                            CustomData>;
 
 struct Packet {
     uint32_t id;

--- a/meshnow/src/receive/queue.cpp
+++ b/meshnow/src/receive/queue.cpp
@@ -16,6 +16,8 @@ void deinit() { queue = util::Queue<Item>{}; }
 
 void push(Item&& item) { queue.push_back(std::move(item), QUEUE_TIMEOUT); }
 
+void push_front(Item&& item) { queue.push_front(std::move(item), QUEUE_TIMEOUT); }
+
 std::optional<Item> pop(TickType_t timeout) { return queue.pop(timeout); }
 
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/queue.cpp
+++ b/meshnow/src/receive/queue.cpp
@@ -1,23 +1,71 @@
 #include "queue.hpp"
+#include <optional>
 
 #include "util/queue.hpp"
 
 static constexpr auto QUEUE_TIMEOUT{pdMS_TO_TICKS(100)};
+static constexpr std::size_t PRIORITY_LEVELS{3};
+static constexpr std::size_t PEOPLE_PER_LEVEL{2};
 static constexpr auto QUEUE_SIZE{128};
 // TODO QUEUE_SIZE has to be higher so not to get deadlocks! FIND A REAL SOLUTION!
 
 namespace meshnow::receive {
 
-static util::Queue<Item> queue;
+static std::array<util::Queue<Item>, PRIORITY_LEVELS> priority_queues;
+//this array helps to insure some amount of fairness between priority levels 
+static std::array<std::size_t, PRIORITY_LEVELS> crowded_timeouts;
 
-esp_err_t init() { return queue.init(QUEUE_SIZE); }
+esp_err_t init() { 
+    for (auto& queue : priority_queues) {
+        auto err = queue.init(QUEUE_SIZE);
+        if (err != ESP_OK) return err;
+    }
+    for (auto i = 0; i < PRIORITY_LEVELS; i++) {
+        crowded_timeouts[i] = (PRIORITY_LEVELS - i)*PEOPLE_PER_LEVEL;
+    }
+    return ESP_OK;
+}
 
-void deinit() { queue = util::Queue<Item>{}; }
+void deinit() { 
+    for (auto& queue : priority_queues) {
+        queue = util::Queue<Item>{};
+    }
+}
 
-void push(Item&& item) { queue.push_back(std::move(item), QUEUE_TIMEOUT); }
+void push(Item&& item) { priority_queues[0].push_back(std::move(item), QUEUE_TIMEOUT); }
 
-void push_front(Item&& item) { queue.push_front(std::move(item), QUEUE_TIMEOUT); }
+void push(Item&& item, p_level level) {
+    if (level < PRIORITY_LEVELS) {
+        priority_queues[level].push_back(std::move(item), QUEUE_TIMEOUT);
+    } else {
+        //the given priority level is higher than the max priority defined in PRIORITY_LEVELS
+        //hence we push this element at the front of the biggest priority subqueue
+        priority_queues[PRIORITY_LEVELS-1].push_front(std::move(item), QUEUE_TIMEOUT);
+    }
+}
+//std::optional<Item> pop(TickType_t timeout) { return priority_queue[0].pop(timeout); }
 
-std::optional<Item> pop(TickType_t timeout) { return queue.pop(timeout); }
+std::optional<Item> pop(TickType_t timeout) {    
+    for (int i = PRIORITY_LEVELS - 1; i >= 0; --i) {
+        //we first go to the high priority queues that still have some
+        //messages to be poped
+        if (priority_queues[i].items_waiting() && crowded_timeouts[i]-- > 0) {
+            //if the crowded_timeouts[i] counter is >= 0, then fetches the elements from the queue
+            return priority_queues[i].pop(timeout);
+        } else {
+            //Here, it could happen that 
+            //  1) we're here because priority_queues[i] was empty. Hence we allow it to have a init value counter
+            //  2) we're here because crowded_timouts[i] has reached 0. This means that, over the last 
+            //      (PRIORITY_LEVELS-i)*PEOPLE_PER_LEVEL pop() calls, the poped item was coming from 
+            //      the queue i. This is too much and i needs to let lower priorities be popped too.
+            //Note that, the higher the priority, the lower the crowded_timouts threshold. This allows to have a 
+            //fairer popping system.
+            crowded_timeouts[i] = (PRIORITY_LEVELS - i)*PEOPLE_PER_LEVEL;
+        }
+    }
+    //just a fallback if very queue is empty
+    return priority_queues[PRIORITY_LEVELS-1].pop(timeout);
+}
 
 }  // namespace meshnow::receive
+

--- a/meshnow/src/receive/queue.cpp
+++ b/meshnow/src/receive/queue.cpp
@@ -4,8 +4,8 @@
 #include "util/queue.hpp"
 
 static constexpr auto QUEUE_TIMEOUT{pdMS_TO_TICKS(100)};
-static constexpr std::size_t PRIORITY_LEVELS{3};
-static constexpr std::size_t PEOPLE_PER_LEVEL{2};
+static constexpr std::size_t PRIORITY_LEVELS{CONFIG_RECEIVER_PRIORITY_QUEUE_LEVELS};
+static constexpr std::size_t PEOPLE_PER_LEVEL{CONFIG_MESSAGES_PER_PRIORITY_LEVEL};
 static constexpr auto QUEUE_SIZE{128};
 // TODO QUEUE_SIZE has to be higher so not to get deadlocks! FIND A REAL SOLUTION!
 
@@ -32,7 +32,7 @@ void deinit() {
     }
 }
 
-void push(Item&& item) { priority_queues[0].push_back(std::move(item), QUEUE_TIMEOUT); }
+void push(Item&& item) { priority_queues[PRIORITY_LEVELS-1].push_back(std::move(item), QUEUE_TIMEOUT); }
 
 void push(Item&& item, p_level level) {
     if (level < PRIORITY_LEVELS) {

--- a/meshnow/src/receive/queue.hpp
+++ b/meshnow/src/receive/queue.hpp
@@ -45,7 +45,7 @@ void deinit();
  *
  * @param item Item to push.
  *
- * @warning the pushed the item with the least
+ * @warning the pushed the item with the highest
  * priority
  */
 void push(Item&& item);

--- a/meshnow/src/receive/queue.hpp
+++ b/meshnow/src/receive/queue.hpp
@@ -23,6 +23,12 @@ struct Item {
     int rssi;
     packets::Packet packet;
 };
+/**
+ * A type defintion to represent priority level
+ *
+ * HIGHER is BETTER
+ */
+typedef std::size_t p_level;
 
 /**
  * Initializes receive queue.
@@ -38,22 +44,32 @@ void deinit();
  * Pushes a new item to the receive queue.
  *
  * @param item Item to push.
+ *
+ * @warning the pushed the item with the least
+ * priority
  */
 void push(Item&& item);
 
 /**
- * Pushed a new item to to top of the receive queue
+ * Pushes a new item at a certain priority level
  *
- * @param Item Item to push
+ * @param item Item to push
+ * @param level Priority level of the item
  */
-void push_front(Item&& item);
-
+void push(Item&& item, p_level level);
 /**
  * Pops an item from the receive queue.
  *
  * @param item Item to pop.
  * @param timeout Timeout in ticks.
+ *
+ * @note When the queue has some non-trivial
+ * priorities, this function fetches the 
+ * highest-priority element. 
+ * To prevent items with low priority to stay
+ * in the queue for ever, a mechanism is set so
+ * that once in a while low priority elements get
+ * fetched.
  */
 std::optional<Item> pop(TickType_t timeout);
-
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/queue.hpp
+++ b/meshnow/src/receive/queue.hpp
@@ -42,6 +42,13 @@ void deinit();
 void push(Item&& item);
 
 /**
+ * Pushed a new item to to top of the receive queue
+ *
+ * @param Item Item to push
+ */
+void push_front(Item&& item);
+
+/**
  * Pops an item from the receive queue.
  *
  * @param item Item to pop.

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -71,11 +71,11 @@ void handle(Item&& item, const PacketType&) {
             ESP_LOGD(TAG, "Receiving CONNECT_OK : pushing at level %d", CONNECT_OK_LEVEL);
             return CONNECT_OK_LEVEL;
         }
-        else if constexpr (std::same_as<PacketType, packets::ConnectOkAck) {
+        else if constexpr (std::same_as<PacketType, packets::ConnectOkAck>) {
             ESP_LOGD(TAG, "Receiving CONNECT_OK_ACK : pushing at level %d", CONNECT_OK_ACK_LEVEL);
             return CONNECT_OK_ACK_LEVEL;
         }
-        else if constexpr (std::same_as<PacketType, packets::ConnectEnd) {
+        else if constexpr (std::same_as<PacketType, packets::ConnectEnd>) {
             ESP_LOGD(TAG, "Receiving CONNECT_ENT : pushing at level %d", CONNECT_END_LEVEL);
             return CONNECT_END_LEVEL;
         }
@@ -101,7 +101,7 @@ void handle(Item&& item, const PacketType&) {
         }
         else {
             ESP_LOGD(TAG, "Receiving UNKNOW : pushing at level 0\n");
-            return 0;
+            return p_level{0};
         }
     }();
     ESP_LOGD(TAG, "Pushing message to level %d", level);

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -39,8 +39,12 @@ constexpr meshnow::receive::p_level SEARCH_PROBE_LEVEL = CONFIG_SEARCH_PROBE_MES
 constexpr meshnow::receive::p_level SEARCH_REPLY_LEVEL = CONFIG_SEARCH_REPLY_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_REQUEST_LEVEL = CONFIG_CONNECT_REQUEST_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_OK_LEVEL = CONFIG_CONNECT_OK_MESSAGE_LEVEL;
+#ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
 constexpr meshnow::receive::p_level CONNECT_OK_ACK_LEVEL = CONFIG_CONNECT_OK_ACK_MESSAGE_LEVEL;
+#endif
+#ifdef CONFIG_USE_CONNECT_END_MESSAGE
 constexpr meshnow::receive::p_level CONNECT_END_LEVEL = CONFIG_CONNECT_END_MESSAGE_LEVEL;
+#endif
 constexpr meshnow::receive::p_level ROUTING_TABLE_ADD_LEVEL = CONFIG_ROUTING_TABLE_ADD_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROUTING_TABLE_REMOVE_LEVEL = CONFIG_ROUTING_TABLE_REMOVE_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROOT_UNREACHABLE_LEVEL = CONFIG_ROOT_UNREACHABLE_MESSAGE_LEVEL;
@@ -71,14 +75,18 @@ void handle(Item&& item, const PacketType&) {
             ESP_LOGD(TAG, "Receiving CONNECT_OK : pushing at level %d", CONNECT_OK_LEVEL);
             return CONNECT_OK_LEVEL;
         }
+        #ifdef CONFIG_USE_CONNECT_OK_ACK_MESSAGE
         else if constexpr (std::same_as<PacketType, packets::ConnectOkAck>) {
             ESP_LOGD(TAG, "Receiving CONNECT_OK_ACK : pushing at level %d", CONNECT_OK_ACK_LEVEL);
             return CONNECT_OK_ACK_LEVEL;
         }
+        #endif
+        #ifdef CONFIG_USE_CONNECT_END_MESSAGE
         else if constexpr (std::same_as<PacketType, packets::ConnectEnd>) {
             ESP_LOGD(TAG, "Receiving CONNECT_ENT : pushing at level %d", CONNECT_END_LEVEL);
             return CONNECT_END_LEVEL;
         }
+        #endif
         else if constexpr (std::same_as<PacketType, packets::RoutingTableAdd>) {
             ESP_LOGD(TAG, "Receiving ROUTING_ADD_TABLE : pushing at level %d", ROUTING_TABLE_ADD_LEVEL);
             return ROUTING_TABLE_ADD_LEVEL;

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -35,7 +35,7 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
 
     if (std::holds_alternative<packets::Status>(item.packet.payload)) {
         // prioritary message : push item to the front of the queue
-        push_front(std::move(item));
+        push(std::move(item), 10);
     } else {
         // not a prioritary message : push item to the end of the queue
         push(std::move(item));

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -1,6 +1,7 @@
 #include "receiver.hpp"
 
 #include <esp_log.h>
+#include <utility>
 
 #include "packets.hpp"
 #include "queue.hpp"
@@ -32,8 +33,13 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
         std::move(*packet),
     };
 
-    // push item to queue
-    push(std::move(item));
+    if (std::holds_alternative<packets::Status>(item.packet.payload)) {
+        // prioritary message : push item to the front of the queue
+        push_front(std::move(item));
+    } else {
+        // not a prioritary message : push item to the end of the queue
+        push(std::move(item));
+    }
 }
 
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -2,16 +2,46 @@
 
 #include <esp_log.h>
 #include <utility>
+#include <variant>
 
 #include "packets.hpp"
 #include "queue.hpp"
+#include "state.hpp"
+#include "util/mac.hpp"
 
 namespace meshnow::receive {
 
 namespace {
 constexpr auto TAG = CREATE_TAG("Receiver");
+constexpr meshnow::receive::p_level STATUS_LEVEL = CONFIG_STATUS_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level SEARCH_PROVE_LEVEL = CONFIG_SEARCH_PROBE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level SEARCH_REPLY_LEVEL = CONFIG_SEARCH_REPLY_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CONNECT_REQUEST_LEVEL = CONFIG_CONNECT_REQUEST_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CONNECT_OK_LEVEL = CONFIG_CONNECT_OK_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level ROUTING_TABLE_ADD_LEVEL = CONFIG_ROUTING_TABLE_ADD_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level ROUTING_TABLE_REMOVE_LEVEL = CONFIG_ROUTING_TABLE_REMOVE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level ROOT_UNREACHABLE_LEVEL = CONFIG_ROOT_UNREACHABLE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level ROOT_REACHABLE_LEVEL = CONFIG_ROOT_REACHABLE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level DATA_FRAGMENT_LEVEL = CONFIG_DATA_FRAGMENT_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CUSTOM_DATA_LEVEL = CONFIG_CUSTOM_DATA_MESSAGE_LEVEL;
 }
+template<typename PacketType>
+void handle(Item&& item, const PacketType&) {
+    constexpr p_level level =
+        std::same_as<PacketType, packets::Status>             ? STATUS_LEVEL :
+        std::same_as<PacketType, packets::SearchProbe>        ? SEARCH_PROVE_LEVEL :
+        std::same_as<PacketType, packets::SearchReply>        ? SEARCH_REPLY_LEVEL :
+        std::same_as<PacketType, packets::ConnectRequest>     ? CONNECT_REQUEST_LEVEL :
+        std::same_as<PacketType, packets::ConnectOk>          ? CONNECT_OK_LEVEL :
+        std::same_as<PacketType, packets::RoutingTableAdd>    ? ROUTING_TABLE_ADD_LEVEL :
+        std::same_as<PacketType, packets::RoutingTableRemove> ? ROUTING_TABLE_REMOVE_LEVEL :
+        std::same_as<PacketType, packets::RootUnreachable>    ? ROOT_UNREACHABLE_LEVEL :
+        std::same_as<PacketType, packets::RootReachable>      ? ROOT_REACHABLE_LEVEL :
+        std::same_as<PacketType, packets::DataFragment>       ? DATA_FRAGMENT_LEVEL :
+                                                               0;
 
+    push(std::move(item), level);
+}
 void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
     // convert raw data pointer into buffer (vector) for deserialization TODO avoid this
     std::vector<uint8_t> buffer(data, data + data_len);
@@ -32,12 +62,10 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
         esp_now_info->rx_ctrl->rssi,
         std::move(*packet),
     };
-
-    if (std::holds_alternative<packets::Status>(item.packet.payload)) {
-        // prioritary message : push item to the front of the queue
-        push(std::move(item), 10);
+    if (item.packet.to == state::getThisMac() || (item.packet.to == util::MacAddr::root() && state::isRoot())) {
+        handle(std::move(item), item.packet.payload);
     } else {
-        // not a prioritary message : push item to the end of the queue
+        //if the packet should be forwarded, this should be handled with high priority
         push(std::move(item));
     }
 }

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -61,44 +61,24 @@ void handle(Item&& item, const PacketType&) {
         std::same_as<PacketType, packets::DataFragment>       ? DATA_FRAGMENT_LEVEL :
                                                                0;
 
-<<<<<<< HEAD
-void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info,
-                               const uint8_t *data, int data_len) {
-  // convert raw data pointer into buffer (vector) for deserialization TODO
-  // avoid this
-  std::vector<uint8_t> buffer(data, data + data_len);
-=======
     push(std::move(item), level);
 }
 void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
     // convert raw data pointer into buffer (vector) for deserialization TODO avoid this
     std::vector<uint8_t> buffer(data, data + data_len);
->>>>>>> 2026/N1/messages_priorities
 
-  // deserialize
-  auto packet = packets::deserialize(buffer);
+    // deserialize
+    auto packet = packets::deserialize(buffer);
 
-  // if deserialization failed, ignore
-  // could happen because of interference with connecting to a router
-  if (!packet) {
-    ESP_LOGV(TAG, "Failed to deserialize packet!");
-    return;
-  }
+    // if deserialization failed, ignore
+    // could happen because of interference with connecting to a router
+    if (!packet) {
+        ESP_LOGV(TAG, "Failed to deserialize packet!");
+        return;
+    }
 
-<<<<<<< HEAD
-  // update last seen
-  update_last_seen(util::MacAddr(esp_now_info->src_addr));
-
-  // create item
-  Item item{
-      util::MacAddr(esp_now_info->src_addr),
-      esp_now_info->rx_ctrl->rssi,
-      std::move(*packet),
-  };
-
-  // push item to queue
-  push(std::move(item));
-=======
+    // update last seen
+    update_last_seen(util::MacAddr(esp_now_info->src_addr));
     // create item
     Item item{
         util::MacAddr(esp_now_info->src_addr),
@@ -111,7 +91,6 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
         //if the packet should be forwarded, this should be handled with high priority
         push(std::move(item));
     }
->>>>>>> 2026/N1/messages_priorities
 }
 
 }  // namespace meshnow::receive

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -39,6 +39,8 @@ constexpr meshnow::receive::p_level SEARCH_PROBE_LEVEL = CONFIG_SEARCH_PROBE_MES
 constexpr meshnow::receive::p_level SEARCH_REPLY_LEVEL = CONFIG_SEARCH_REPLY_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_REQUEST_LEVEL = CONFIG_CONNECT_REQUEST_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_OK_LEVEL = CONFIG_CONNECT_OK_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CONNECT_OK_ACK_LEVEL = CONFIG_CONNECT_OK_ACK_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level CONNECT_END_LEVEL = CONFIG_CONNECT_END_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROUTING_TABLE_ADD_LEVEL = CONFIG_ROUTING_TABLE_ADD_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROUTING_TABLE_REMOVE_LEVEL = CONFIG_ROUTING_TABLE_REMOVE_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level ROOT_UNREACHABLE_LEVEL = CONFIG_ROOT_UNREACHABLE_MESSAGE_LEVEL;
@@ -66,8 +68,16 @@ void handle(Item&& item, const PacketType&) {
             return CONNECT_REQUEST_LEVEL;
         }
         else if constexpr (std::same_as<PacketType, packets::ConnectOk>) {
-            ESP_LOGD(TAG, "Receiving CONNECTOK : pushing at level %d", CONNECT_OK_LEVEL);
+            ESP_LOGD(TAG, "Receiving CONNECT_OK : pushing at level %d", CONNECT_OK_LEVEL);
             return CONNECT_OK_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::ConnectOkAck) {
+            ESP_LOGD(TAG, "Receiving CONNECT_OK_ACK : pushing at level %d", CONNECT_OK_ACK_LEVEL);
+            return CONNECT_OK_ACK_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::ConnectEnd) {
+            ESP_LOGD(TAG, "Receiving CONNECT_ENT : pushing at level %d", CONNECT_END_LEVEL);
+            return CONNECT_END_LEVEL;
         }
         else if constexpr (std::same_as<PacketType, packets::RoutingTableAdd>) {
             ESP_LOGD(TAG, "Receiving ROUTING_ADD_TABLE : pushing at level %d", ROUTING_TABLE_ADD_LEVEL);

--- a/meshnow/src/receive/receiver.cpp
+++ b/meshnow/src/receive/receiver.cpp
@@ -14,7 +14,7 @@ namespace meshnow::receive {
 namespace {
 constexpr auto TAG = CREATE_TAG("Receiver");
 constexpr meshnow::receive::p_level STATUS_LEVEL = CONFIG_STATUS_MESSAGE_LEVEL;
-constexpr meshnow::receive::p_level SEARCH_PROVE_LEVEL = CONFIG_SEARCH_PROBE_MESSAGE_LEVEL;
+constexpr meshnow::receive::p_level SEARCH_PROBE_LEVEL = CONFIG_SEARCH_PROBE_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level SEARCH_REPLY_LEVEL = CONFIG_SEARCH_REPLY_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_REQUEST_LEVEL = CONFIG_CONNECT_REQUEST_MESSAGE_LEVEL;
 constexpr meshnow::receive::p_level CONNECT_OK_LEVEL = CONFIG_CONNECT_OK_MESSAGE_LEVEL;
@@ -27,19 +27,53 @@ constexpr meshnow::receive::p_level CUSTOM_DATA_LEVEL = CONFIG_CUSTOM_DATA_MESSA
 }
 template<typename PacketType>
 void handle(Item&& item, const PacketType&) {
-    constexpr p_level level =
-        std::same_as<PacketType, packets::Status>             ? STATUS_LEVEL :
-        std::same_as<PacketType, packets::SearchProbe>        ? SEARCH_PROVE_LEVEL :
-        std::same_as<PacketType, packets::SearchReply>        ? SEARCH_REPLY_LEVEL :
-        std::same_as<PacketType, packets::ConnectRequest>     ? CONNECT_REQUEST_LEVEL :
-        std::same_as<PacketType, packets::ConnectOk>          ? CONNECT_OK_LEVEL :
-        std::same_as<PacketType, packets::RoutingTableAdd>    ? ROUTING_TABLE_ADD_LEVEL :
-        std::same_as<PacketType, packets::RoutingTableRemove> ? ROUTING_TABLE_REMOVE_LEVEL :
-        std::same_as<PacketType, packets::RootUnreachable>    ? ROOT_UNREACHABLE_LEVEL :
-        std::same_as<PacketType, packets::RootReachable>      ? ROOT_REACHABLE_LEVEL :
-        std::same_as<PacketType, packets::DataFragment>       ? DATA_FRAGMENT_LEVEL :
-                                                               0;
-
+    p_level level = [] {
+        if constexpr (std::same_as<PacketType, packets::Status>) {
+            ESP_LOGD(TAG, "Receiving STATUS : pushing at level %d", STATUS_LEVEL);
+            return STATUS_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::SearchProbe>) {
+            ESP_LOGD(TAG, "Receiving SEARCH_PROBE : pushing at level %d", SEARCH_PROBE_LEVEL);
+            return SEARCH_PROBE_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::SearchReply>) {
+            ESP_LOGD(TAG, "Receiving SEARCH_REPLY : pushing at level %d", SEARCH_REPLY_LEVEL);
+            return SEARCH_REPLY_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::ConnectRequest>) {
+            ESP_LOGD(TAG, "Receiving CONNECT_REQUEST : pushing at level %d", CONNECT_REQUEST_LEVEL);
+            return CONNECT_REQUEST_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::ConnectOk>) {
+            ESP_LOGD(TAG, "Receiving CONNECTOK : pushing at level %d", CONNECT_OK_LEVEL);
+            return CONNECT_OK_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::RoutingTableAdd>) {
+            ESP_LOGD(TAG, "Receiving ROUTING_ADD_TABLE : pushing at level %d", ROUTING_TABLE_ADD_LEVEL);
+            return ROUTING_TABLE_ADD_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::RoutingTableRemove>) {
+            ESP_LOGD(TAG, "Receiving ROUTING_REM_TABLE : pushing at level %d", ROUTING_TABLE_REMOVE_LEVEL);
+            return ROUTING_TABLE_REMOVE_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::RootUnreachable>) {
+            ESP_LOGD(TAG, "Receiving ROOT_UNREACHABLE : pushing at level %d", ROOT_UNREACHABLE_LEVEL);
+            return ROOT_UNREACHABLE_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::RootReachable>) {
+            ESP_LOGD(TAG, "Receiving ROOT_REACHABLE : pushing at level %d", ROOT_REACHABLE_LEVEL);
+            return ROOT_REACHABLE_LEVEL;
+        }
+        else if constexpr (std::same_as<PacketType, packets::DataFragment>) {
+            ESP_LOGD(TAG, "Receiving DATAFRAGM : pushing at level %d", DATA_FRAGMENT_LEVEL);
+            return DATA_FRAGMENT_LEVEL;
+        }
+        else {
+            ESP_LOGD(TAG, "Receiving UNKNOW : pushing at level 0\n");
+            return 0;
+        }
+    }();
+    ESP_LOGD(TAG, "Pushing message to level %d", level);
     push(std::move(item), level);
 }
 void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len) {
@@ -63,7 +97,7 @@ void Receiver::receiveCallback(const esp_now_recv_info_t *esp_now_info, const ui
         std::move(*packet),
     };
     if (item.packet.to == state::getThisMac() || (item.packet.to == util::MacAddr::root() && state::isRoot())) {
-        handle(std::move(item), item.packet.payload);
+        std::visit([&](const auto& payload) { handle(std::move(item), payload); }, item.packet.payload);    
     } else {
         //if the packet should be forwarded, this should be handled with high priority
         push(std::move(item));


### PR DESCRIPTION
This PR includes the following features (they are merged in one because some features need to me modified when some other are included and otherwise it is a mess) :

- Introduce a ConnectEnd message for false timeouts
- Introduce a ConnectOkAck message that the child sends to the parent to confirm the beginning of a connection
- Modify Status packets so that they contain a seq number, which allows to compute RTTS
- Modifiy the logic of the sending of Status packets so that when received, they are being replied, and a reply allows to compute a specific RTTs for each neighbor node.
- Timeouts are based on RTTs according to RFC 2988.
- Introduce a configurable priority queue at the receiver, so that important messages are treated before less important ones. 