### PR TITLE
2026/n1/disconnect reason

### DIFF
--- a/meshnow/src/include/meshnow.h
+++ b/meshnow/src/include/meshnow.h
@@ -50,6 +50,21 @@ typedef enum {
 } meshnow_event_t;
 
 /**
+ * Reason for the disconnection
+ */
+typedef enum {
+    /**
+     * The neighbor timed out 
+     */
+    TIME_OUT,
+
+    /**
+     * The neighbor sent a connect_end message
+     */
+    CONNECT_END_MESSAGE,
+} meshnow_event_disconnected_reason_t;
+
+/**
  * Child connected information.
  */
 typedef struct {
@@ -67,6 +82,10 @@ typedef struct {
      * MAC address of the disconnected child.
      */
     meshnow_addr_t child_mac;
+    /**
+     * Disconnection reason
+     */
+    meshnow_event_disconnected_reason_t reason;
 } meshnow_event_child_disconnected_t;
 
 /**
@@ -89,6 +108,10 @@ typedef struct {
      * MAC address of the parent from which this node disconnected.
      */
     meshnow_addr_t parent_mac;
+    /**
+     * Disconnection reason
+     */
+    meshnow_event_disconnected_reason_t reason;
 } meshnow_event_parent_disconnected_t;
 
 /**

--- a/meshnow/src/include/meshnow.h
+++ b/meshnow/src/include/meshnow.h
@@ -56,12 +56,17 @@ typedef enum {
     /**
      * The neighbor timed out 
      */
-    TIME_OUT,
+    DISCONNECT_REASON_TIME_OUT,
+
+    /**
+     * The parent has no acces to the root since too long
+     */
+    DISCONNECT_REASON_ROOT_UNREACHABLE,
 
     /**
      * The neighbor sent a connect_end message
      */
-    CONNECT_END_MESSAGE,
+    DISCONNECT_REASON_CONNECT_END_MESSAGE,
 } meshnow_event_disconnected_reason_t;
 
 /**

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -104,6 +104,7 @@ void UnreachableTimeoutJob::performAction() {
             {
                 meshnow_event_parent_disconnected_t parent_disconnected_event;
                 std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_disconnected_event.parent_mac);
+                parent_disconnected_event.reason = DISCONNECT_REASON_ROOT_UNREACHABLE;
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }
@@ -188,6 +189,7 @@ void NeighborCheckJob::performAction() {
             {
                 meshnow_event_child_disconnected_t child_disconnected_event;
                 std::copy(mac.addr.begin(), mac.addr.end(), child_disconnected_event.child_mac);
+                child_disconnected_event.reason = DISCONNECT_REASON_TIME_OUT:
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
                                &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
             }
@@ -219,6 +221,7 @@ void NeighborCheckJob::performAction() {
                 meshnow_event_parent_disconnected_t parent_disconnected_event;
                 util::MacAddr& parent_mac = layout::Layout::get().getParent().mac;
                 std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_disconnected_event.parent_mac);
+                parent_disconnected_event.reason = DISCONNECT_REASON_TIME_OUT:
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -189,7 +189,7 @@ void NeighborCheckJob::performAction() {
             {
                 meshnow_event_child_disconnected_t child_disconnected_event;
                 std::copy(mac.addr.begin(), mac.addr.end(), child_disconnected_event.child_mac);
-                child_disconnected_event.reason = DISCONNECT_REASON_TIME_OUT:
+                child_disconnected_event.reason = DISCONNECT_REASON_TIME_OUT;
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
                                &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
             }
@@ -221,7 +221,7 @@ void NeighborCheckJob::performAction() {
                 meshnow_event_parent_disconnected_t parent_disconnected_event;
                 util::MacAddr& parent_mac = layout::Layout::get().getParent().mac;
                 std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_disconnected_event.parent_mac);
-                parent_disconnected_event.reason = DISCONNECT_REASON_TIME_OUT:
+                parent_disconnected_event.reason = DISCONNECT_REASON_TIME_OUT;
                 esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                                &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
             }

--- a/meshnow/src/job/packet_handler.cpp
+++ b/meshnow/src/job/packet_handler.cpp
@@ -343,6 +343,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
             meshnow_event_parent_disconnected_t parent_disconnected_event;
             util::MacAddr& parent_mac = layout.getParent().mac;
             std::copy(parent_mac.addr.begin(), parent_mac.addr.end(), parent_disconnected_event.parent_mac);
+            parent_disconnected_event.reason = DISCONNECT_REASON_CONNECT_END_MESSAGE;
             esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_PARENT_DISCONNECTED,
                            &parent_disconnected_event, sizeof(parent_disconnected_event), portMAX_DELAY);
         }
@@ -358,6 +359,7 @@ void PacketHandler::handle(const MetaData& meta, const packets::ConnectEnd&) {
         {
             meshnow_event_child_disconnected_t child_disconnected_event;
             std::copy(meta.from.addr.begin(), meta.from.addr.end(), child_disconnected_event.child_mac);
+            child_disconnected_event.reason = DISCONNECT_REASON_CONNECT_END_MESSAGE;
             esp_event_post(MESHNOW_EVENT, meshnow_event_t::MESHNOW_EVENT_CHILD_DISCONNECTED,
                            &child_disconnected_event, sizeof(child_disconnected_event), portMAX_DELAY);
         }


### PR DESCRIPTION
Adds a disconnect reason to the disconnected event data, so that we can display in "✨MeshNOW✨ | Event" the reason for disconnection