### PR TITLE
Changed the connect phase transition logic

### DIFF
--- a/meshnow/src/event.hpp
+++ b/meshnow/src/event.hpp
@@ -21,6 +21,7 @@ enum class InternalEvent : int32_t {
 struct StateChangedEvent {
     const state::State old_state;
     const state::State new_state;
+    const state::StateChangeReason reason;
 };
 
 struct ParentFoundData {

--- a/meshnow/src/job/connect.cpp
+++ b/meshnow/src/job/connect.cpp
@@ -405,7 +405,11 @@ void ConnectJob::DonePhase::event_handler(meshnow::job::ConnectJob &job, event::
     ESP_LOGI(TAG, "new State: %d", static_cast<uint8_t>(state_change.new_state));
 
     if (state_change.new_state == state::State::DISCONNECTED_FROM_PARENT) {
-        job.phase_ = ReconnectPhase{current_parent_mac_};
+        if (state_change.reason == state::StateChangeReason::ROOT_UNREACHABLE) {
+            job.phase_ = SearchPhase{job.channel_config_};
+        } else {
+            job.phase_ = ReconnectPhase{current_parent_mac_};
+        }
     }
 }
 

--- a/meshnow/src/job/keep_alive.cpp
+++ b/meshnow/src/job/keep_alive.cpp
@@ -113,7 +113,7 @@ void UnreachableTimeoutJob::performAction() {
             send::enqueuePayload(packets::ConnectEnd{}, send::DirectOnce(parent_mac));
             #endif
             layout.removeParent();
-            state::setState(state::State::DISCONNECTED_FROM_PARENT);
+            state::setState(state::State::DISCONNECTED_FROM_PARENT, state::StateChangeReason::ROOT_UNREACHABLE);
         }
     }
 }

--- a/meshnow/src/state.cpp
+++ b/meshnow/src/state.cpp
@@ -22,13 +22,14 @@ State state{State::DISCONNECTED_FROM_PARENT};
 
 }  // namespace
 
-void setState(State new_state) {
+void setState(State new_state, StateChangeReason reason) {
     ESP_LOGD(TAG, "Requested state change from %d to %d", static_cast<uint8_t>(state), static_cast<uint8_t>(new_state));
     if (new_state == state) return;
 
     event::StateChangedEvent data{
         .old_state = state,
         .new_state = new_state,
+        .reason = reason, 
     };
 
     state = new_state;

--- a/meshnow/src/state.hpp
+++ b/meshnow/src/state.hpp
@@ -5,11 +5,12 @@
 namespace meshnow::state {
 
 enum class State : std::uint8_t { DISCONNECTED_FROM_PARENT, CONNECTED_TO_PARENT, REACHES_ROOT };
+enum class StateChangeReason : std::uint8_t { NO_REASON, ROOT_UNREACHABLE};
 
 /**
  * Sets the current state.
  */
-void setState(State state);
+void setState(State state, StateChangeReason reason = StateChangeReason::NO_REASON);
 
 /**
  * Returns the current state.


### PR DESCRIPTION
If the connect job is in the DonePhase a receive a state change event that is originated by a RootUnreachableTimeout, instead of going to the reconnect phase, the next phase is now the search phase.

This change induces a few modifications in several files as listed:
   * meshnow/src/event.hpp : in StateChangedEvent, added a StateChangeReason reason to be used by the conenct job
   * meshnow/src/job/connect.cpp : in the done phase event handler, goes back to Seach Phase if the reason that caused the sate change is a RootUnreachable message sent from the parent
   * meshnow/src/job/keep_alive.cpp : add a state change reason in the RootUnreachable timeout job.
   * meshnow/src/state.cpp : changed the signature of setState to include a state change reason. Adds this reason to the StateChangedEvent structure
   * meshnow/src/state.hpp : add a StateChangeReason enum and add a StateChangeReason parameter to the setState function, with a default value of NO_REASON